### PR TITLE
feat(openai): add embeddings resource for text embedding generation

### DIFF
--- a/packages/openai/src/openai_provider/__init__.py
+++ b/packages/openai/src/openai_provider/__init__.py
@@ -1,6 +1,6 @@
 """OpenAI provider for Pragmatiks.
 
-Provides Chat Completions API resources for AI completions
+Provides Chat Completions and Embeddings API resources
 with reactive dependency management.
 """
 
@@ -10,16 +10,27 @@ from openai_provider.resources import (
     ChatCompletions,
     ChatCompletionsConfig,
     ChatCompletionsOutputs,
+    EmbedInput,
+    EmbedOutput,
+    Embeddings,
+    EmbeddingsConfig,
+    EmbeddingsOutputs,
 )
 
 openai = Provider(name="openai")
 
 # Register resources
 openai.resource("chat_completions")(ChatCompletions)
+openai.resource("embeddings")(Embeddings)
 
 __all__ = [
     "openai",
     "ChatCompletions",
     "ChatCompletionsConfig",
     "ChatCompletionsOutputs",
+    "EmbedInput",
+    "EmbedOutput",
+    "Embeddings",
+    "EmbeddingsConfig",
+    "EmbeddingsOutputs",
 ]

--- a/packages/openai/src/openai_provider/resources/__init__.py
+++ b/packages/openai/src/openai_provider/resources/__init__.py
@@ -8,9 +8,21 @@ from openai_provider.resources.chat_completions import (
     ChatCompletionsConfig,
     ChatCompletionsOutputs,
 )
+from openai_provider.resources.embeddings import (
+    EmbedInput,
+    EmbedOutput,
+    Embeddings,
+    EmbeddingsConfig,
+    EmbeddingsOutputs,
+)
 
 __all__ = [
     "ChatCompletions",
     "ChatCompletionsConfig",
     "ChatCompletionsOutputs",
+    "EmbedInput",
+    "EmbedOutput",
+    "Embeddings",
+    "EmbeddingsConfig",
+    "EmbeddingsOutputs",
 ]

--- a/packages/openai/src/openai_provider/resources/embeddings.py
+++ b/packages/openai/src/openai_provider/resources/embeddings.py
@@ -1,0 +1,147 @@
+"""OpenAI Embeddings API resource."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from openai import AsyncOpenAI
+from pydantic import BaseModel
+from pragma_sdk import Config, Field, Outputs, Resource
+
+
+class EmbeddingsConfig(Config):
+    """Configuration for OpenAI Embeddings API.
+
+    Attributes:
+        api_key: OpenAI API key. Use a FieldReference to inject from pragma/secret.
+        model: Model identifier (e.g., "text-embedding-3-small", "text-embedding-3-large").
+        dimensions: Optional dimension override for models that support it.
+    """
+
+    api_key: Field[str]
+    model: str = "text-embedding-3-small"
+    dimensions: int | None = None
+
+
+class EmbeddingsOutputs(Outputs):
+    """Outputs from OpenAI Embeddings resource validation.
+
+    Attributes:
+        model: Model used for embeddings.
+        dimensions: Embedding dimensions.
+        ready: Whether the resource is ready to generate embeddings.
+    """
+
+    model: str
+    dimensions: int
+    ready: bool
+
+
+class EmbedInput(BaseModel):
+    """Input for the embed action.
+
+    Attributes:
+        text: Text or list of texts to generate embeddings for.
+    """
+
+    text: str | list[str]
+
+
+class EmbedOutput(BaseModel):
+    """Output from the embed action.
+
+    Attributes:
+        embeddings: List of embedding vectors.
+        model: Model used to generate embeddings.
+        usage: Token usage information.
+    """
+
+    embeddings: list[list[float]]
+    model: str
+    usage: dict[str, Any]
+
+
+class Embeddings(Resource[EmbeddingsConfig, EmbeddingsOutputs]):
+    """OpenAI Embeddings API resource.
+
+    Wraps the OpenAI Embeddings API for generating text embeddings.
+    API keys can be injected via FieldReference from pragma/secret resources.
+
+    Lifecycle:
+        - on_create: Validate API key and model, return model info
+        - on_update: Re-validate if config changed
+        - on_delete: No-op (stateless)
+
+    Actions:
+        - embed: Generate embeddings for text
+    """
+
+    provider: ClassVar[str] = "openai"
+    resource: ClassVar[str] = "embeddings"
+
+    def _get_client(self) -> AsyncOpenAI:
+        """Get OpenAI async client with configured API key."""
+        return AsyncOpenAI(api_key=self.config.api_key)
+
+    async def _validate_model(self) -> EmbeddingsOutputs:
+        """Validate the API key and model by making a test embedding request."""
+        async with self._get_client() as client:
+            # Make a minimal embedding request to validate credentials and model
+            kwargs: dict[str, Any] = {
+                "model": self.config.model,
+                "input": "test",
+            }
+
+            if self.config.dimensions is not None:
+                kwargs["dimensions"] = self.config.dimensions
+
+            response = await client.embeddings.create(**kwargs)
+
+            # Get the actual dimensions from the response
+            dimensions = len(response.data[0].embedding)
+
+            return EmbeddingsOutputs(
+                model=response.model,
+                dimensions=dimensions,
+                ready=True,
+            )
+
+    async def on_create(self) -> EmbeddingsOutputs:
+        """Create by validating API key and model."""
+        return await self._validate_model()
+
+    async def on_update(self, previous_config: EmbeddingsConfig) -> EmbeddingsOutputs:
+        """Update by re-validating if config changed."""
+        if previous_config == self.config and self.outputs is not None:
+            return self.outputs
+
+        return await self._validate_model()
+
+    async def on_delete(self) -> None:
+        """Delete is a no-op since this resource is stateless."""
+
+    async def embed(self, input: EmbedInput) -> EmbedOutput:
+        """Generate embeddings for text.
+
+        Args:
+            input: Text or list of texts to generate embeddings for.
+
+        Returns:
+            Embedding vectors with model and usage information.
+        """
+        async with self._get_client() as client:
+            kwargs: dict[str, Any] = {
+                "model": self.config.model,
+                "input": input.text,
+            }
+
+            if self.config.dimensions is not None:
+                kwargs["dimensions"] = self.config.dimensions
+
+            response = await client.embeddings.create(**kwargs)
+
+            return EmbedOutput(
+                embeddings=[e.embedding for e in response.data],
+                model=response.model,
+                usage=response.usage.model_dump(),
+            )

--- a/packages/openai/tests/conftest.py
+++ b/packages/openai/tests/conftest.py
@@ -57,3 +57,76 @@ def mock_openai_client(mocker: "MockerFixture") -> "MockType":
     )
 
     return mock_client
+
+
+@pytest.fixture
+def mock_embeddings_client(mocker: "MockerFixture") -> "MockType":
+    """Mock AsyncOpenAI client for embeddings with async context manager support."""
+    mock_client = mocker.MagicMock()
+
+    # Mock embedding response (single embedding)
+    mock_embedding = mocker.MagicMock()
+    mock_embedding.embedding = [0.1] * 1536  # 1536-dimensional embedding
+
+    mock_usage = mocker.MagicMock()
+    mock_usage.prompt_tokens = 2
+    mock_usage.total_tokens = 2
+    mock_usage.model_dump.return_value = {"prompt_tokens": 2, "total_tokens": 2}
+
+    mock_response = mocker.MagicMock()
+    mock_response.data = [mock_embedding]
+    mock_response.model = "text-embedding-3-small"
+    mock_response.usage = mock_usage
+
+    mock_embeddings = mocker.MagicMock()
+    mock_embeddings.create = mocker.AsyncMock(return_value=mock_response)
+    mock_client.embeddings = mock_embeddings
+
+    # Support async context manager protocol
+    mock_client.__aenter__ = mocker.AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = mocker.AsyncMock(return_value=None)
+
+    mocker.patch(
+        "openai_provider.resources.embeddings.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    return mock_client
+
+
+@pytest.fixture
+def mock_embeddings_client_batch(mocker: "MockerFixture") -> "MockType":
+    """Mock AsyncOpenAI client for batch embeddings with async context manager support."""
+    mock_client = mocker.MagicMock()
+
+    # Mock embedding response (multiple embeddings)
+    mock_embedding_1 = mocker.MagicMock()
+    mock_embedding_1.embedding = [0.1] * 1536
+
+    mock_embedding_2 = mocker.MagicMock()
+    mock_embedding_2.embedding = [0.2] * 1536
+
+    mock_usage = mocker.MagicMock()
+    mock_usage.prompt_tokens = 4
+    mock_usage.total_tokens = 4
+    mock_usage.model_dump.return_value = {"prompt_tokens": 4, "total_tokens": 4}
+
+    mock_response = mocker.MagicMock()
+    mock_response.data = [mock_embedding_1, mock_embedding_2]
+    mock_response.model = "text-embedding-3-small"
+    mock_response.usage = mock_usage
+
+    mock_embeddings = mocker.MagicMock()
+    mock_embeddings.create = mocker.AsyncMock(return_value=mock_response)
+    mock_client.embeddings = mock_embeddings
+
+    # Support async context manager protocol
+    mock_client.__aenter__ = mocker.AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = mocker.AsyncMock(return_value=None)
+
+    mocker.patch(
+        "openai_provider.resources.embeddings.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    return mock_client

--- a/packages/openai/tests/test_embeddings.py
+++ b/packages/openai/tests/test_embeddings.py
@@ -1,0 +1,298 @@
+"""Tests for OpenAI Embeddings resource."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from openai import APIError
+from pragma_sdk.provider import ProviderHarness
+
+from openai_provider import (
+    EmbedInput,
+    Embeddings,
+    EmbeddingsConfig,
+    EmbeddingsOutputs,
+)
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture, MockType
+
+
+async def test_create_embeddings_success(
+    harness: ProviderHarness,
+    mock_embeddings_client: "MockType",
+) -> None:
+    """on_create validates API key and returns model info."""
+    config = EmbeddingsConfig(
+        api_key="sk-test-key",
+        model="text-embedding-3-small",
+    )
+
+    result = await harness.invoke_create(Embeddings, name="test-embeddings", config=config)
+
+    assert result.success
+    assert result.outputs is not None
+    assert result.outputs.model == "text-embedding-3-small"
+    assert result.outputs.dimensions == 1536
+    assert result.outputs.ready is True
+
+    mock_embeddings_client.embeddings.create.assert_called_once()
+
+
+async def test_create_embeddings_with_dimensions(
+    harness: ProviderHarness,
+    mock_embeddings_client: "MockType",
+) -> None:
+    """on_create passes dimensions to API when specified."""
+    config = EmbeddingsConfig(
+        api_key="sk-test-key",
+        model="text-embedding-3-small",
+        dimensions=512,
+    )
+
+    result = await harness.invoke_create(Embeddings, name="test-embeddings", config=config)
+
+    assert result.success
+    call_kwargs = mock_embeddings_client.embeddings.create.call_args.kwargs
+    assert call_kwargs["dimensions"] == 512
+
+
+async def test_create_embeddings_without_dimensions(
+    harness: ProviderHarness,
+    mock_embeddings_client: "MockType",
+) -> None:
+    """on_create omits dimensions when not specified."""
+    config = EmbeddingsConfig(
+        api_key="sk-test-key",
+        model="text-embedding-3-small",
+    )
+
+    result = await harness.invoke_create(Embeddings, name="test-embeddings", config=config)
+
+    assert result.success
+    call_kwargs = mock_embeddings_client.embeddings.create.call_args.kwargs
+    assert "dimensions" not in call_kwargs
+
+
+async def test_update_revalidates_on_model_change(
+    harness: ProviderHarness,
+    mock_embeddings_client: "MockType",
+) -> None:
+    """on_update revalidates when model changes."""
+    previous = EmbeddingsConfig(
+        api_key="sk-test-key",
+        model="text-embedding-3-small",
+    )
+    current = EmbeddingsConfig(
+        api_key="sk-test-key",
+        model="text-embedding-3-large",
+    )
+
+    result = await harness.invoke_update(
+        Embeddings,
+        name="test-embeddings",
+        config=current,
+        previous_config=previous,
+        current_outputs=EmbeddingsOutputs(
+            model="text-embedding-3-small",
+            dimensions=1536,
+            ready=True,
+        ),
+    )
+
+    assert result.success
+    mock_embeddings_client.embeddings.create.assert_called_once()
+
+
+async def test_update_returns_existing_when_unchanged(
+    harness: ProviderHarness,
+    mock_embeddings_client: "MockType",
+) -> None:
+    """on_update returns existing outputs when config unchanged."""
+    config = EmbeddingsConfig(
+        api_key="sk-test-key",
+        model="text-embedding-3-small",
+    )
+    existing_outputs = EmbeddingsOutputs(
+        model="text-embedding-3-small",
+        dimensions=1536,
+        ready=True,
+    )
+
+    result = await harness.invoke_update(
+        Embeddings,
+        name="test-embeddings",
+        config=config,
+        previous_config=config,
+        current_outputs=existing_outputs,
+    )
+
+    assert result.success
+    assert result.outputs == existing_outputs
+    mock_embeddings_client.embeddings.create.assert_not_called()
+
+
+async def test_delete_success(
+    harness: ProviderHarness,
+    mock_embeddings_client: "MockType",
+) -> None:
+    """on_delete completes without error (stateless resource)."""
+    config = EmbeddingsConfig(
+        api_key="sk-test-key",
+        model="text-embedding-3-small",
+    )
+
+    result = await harness.invoke_delete(Embeddings, name="test-embeddings", config=config)
+
+    assert result.success
+    mock_embeddings_client.embeddings.create.assert_not_called()
+
+
+async def test_api_error_propagates(
+    harness: ProviderHarness,
+    mocker: "MockerFixture",
+) -> None:
+    """API errors propagate correctly."""
+    mock_client = mocker.MagicMock()
+    mock_embeddings = mocker.MagicMock()
+    mock_embeddings.create = mocker.AsyncMock(
+        side_effect=APIError(
+            message="Invalid API key",
+            request=mocker.MagicMock(),
+            body={"error": {"message": "Invalid API key"}},
+        )
+    )
+    mock_client.embeddings = mock_embeddings
+
+    # Support async context manager protocol
+    mock_client.__aenter__ = mocker.AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = mocker.AsyncMock(return_value=None)
+
+    mocker.patch(
+        "openai_provider.resources.embeddings.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    config = EmbeddingsConfig(
+        api_key="invalid-key",
+        model="text-embedding-3-small",
+    )
+
+    result = await harness.invoke_create(Embeddings, name="test-embeddings", config=config)
+
+    assert result.failed
+    assert result.error is not None
+    assert "Invalid API key" in str(result.error)
+
+
+async def test_embed_action_single_text(
+    mock_embeddings_client: "MockType",
+) -> None:
+    """embed action generates embeddings for single text."""
+    config = EmbeddingsConfig(
+        api_key="sk-test-key",
+        model="text-embedding-3-small",
+    )
+    resource = Embeddings(
+        name="test-embeddings",
+        config=config,
+        outputs=EmbeddingsOutputs(
+            model="text-embedding-3-small",
+            dimensions=1536,
+            ready=True,
+        ),
+    )
+
+    result = await resource.embed(EmbedInput(text="Hello world"))
+
+    assert result.model == "text-embedding-3-small"
+    assert len(result.embeddings) == 1
+    assert len(result.embeddings[0]) == 1536
+    assert "prompt_tokens" in result.usage
+    assert "total_tokens" in result.usage
+
+
+async def test_embed_action_multiple_texts(
+    mock_embeddings_client_batch: "MockType",
+) -> None:
+    """embed action generates embeddings for multiple texts."""
+    config = EmbeddingsConfig(
+        api_key="sk-test-key",
+        model="text-embedding-3-small",
+    )
+    resource = Embeddings(
+        name="test-embeddings",
+        config=config,
+        outputs=EmbeddingsOutputs(
+            model="text-embedding-3-small",
+            dimensions=1536,
+            ready=True,
+        ),
+    )
+
+    result = await resource.embed(EmbedInput(text=["Hello", "World"]))
+
+    assert result.model == "text-embedding-3-small"
+    assert len(result.embeddings) == 2
+    assert len(result.embeddings[0]) == 1536
+    assert len(result.embeddings[1]) == 1536
+
+
+async def test_embed_action_with_dimensions(
+    mocker: "MockerFixture",
+) -> None:
+    """embed action passes dimensions to API when configured."""
+    mock_client = mocker.MagicMock()
+    mock_embedding = mocker.MagicMock()
+    mock_embedding.embedding = [0.1] * 512  # Reduced dimensions
+
+    mock_usage = mocker.MagicMock()
+    mock_usage.model_dump.return_value = {"prompt_tokens": 2, "total_tokens": 2}
+
+    mock_response = mocker.MagicMock()
+    mock_response.data = [mock_embedding]
+    mock_response.model = "text-embedding-3-small"
+    mock_response.usage = mock_usage
+
+    mock_embeddings = mocker.MagicMock()
+    mock_embeddings.create = mocker.AsyncMock(return_value=mock_response)
+    mock_client.embeddings = mock_embeddings
+
+    mock_client.__aenter__ = mocker.AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = mocker.AsyncMock(return_value=None)
+
+    mocker.patch(
+        "openai_provider.resources.embeddings.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    config = EmbeddingsConfig(
+        api_key="sk-test-key",
+        model="text-embedding-3-small",
+        dimensions=512,
+    )
+    resource = Embeddings(
+        name="test-embeddings",
+        config=config,
+        outputs=EmbeddingsOutputs(
+            model="text-embedding-3-small",
+            dimensions=512,
+            ready=True,
+        ),
+    )
+
+    result = await resource.embed(EmbedInput(text="test"))
+
+    assert len(result.embeddings[0]) == 512
+    call_kwargs = mock_embeddings.create.call_args.kwargs
+    assert call_kwargs["dimensions"] == 512
+
+
+def test_provider_name() -> None:
+    """Resource has correct provider name."""
+    assert Embeddings.provider == "openai"
+
+
+def test_resource_type() -> None:
+    """Resource has correct resource type."""
+    assert Embeddings.resource == "embeddings"


### PR DESCRIPTION
## Summary

- Add new `embeddings` resource to the OpenAI provider for generating text embeddings
- Implement config with `api_key`, `model`, and optional `dimensions` parameters
- Add lifecycle methods (`on_create` validates API key, `on_update` re-validates on config change)
- Add `embed()` method for generating embeddings from single or batch text inputs
- Full test coverage with mocked OpenAI API

## Resource Spec

```yaml
apiVersion: openai/v1
kind: embeddings
metadata:
  name: my-embeddings
  namespace: demo
spec:
  api_key: $ref{openai-secret.data.api_key}
  model: text-embedding-3-small
  dimensions: 1536
```

## Test plan

- [x] Tests pass with `task test` (22 tests, 100% coverage)
- [x] Linting and type checking pass with `task check`
- [ ] Manual testing with real OpenAI API (optional)

Resolves: PRA-111