### PR TITLE
fix(gcp): use Dependency.resolve() for instance access

### DIFF
--- a/packages/gcp/src/gcp_provider/resources/cloudsql/database.py
+++ b/packages/gcp/src/gcp_provider/resources/cloudsql/database.py
@@ -58,7 +58,8 @@ class Database(Resource[DatabaseConfig, DatabaseOutputs]):
 
         Idempotent: If database already exists, returns its current state.
         """
-        inst = self.config.instance.config
+        instance_resource = await self.config.instance.resolve()
+        inst = instance_resource.config
         service = get_sqladmin_service(get_credentials(inst.credentials))
 
         await execute(
@@ -90,7 +91,8 @@ class Database(Resource[DatabaseConfig, DatabaseOutputs]):
             await self._delete(previous_config)
             return await self.on_create()
 
-        inst = self.config.instance.config
+        instance_resource = await self.config.instance.resolve()
+        inst = instance_resource.config
         service = get_sqladmin_service(get_credentials(inst.credentials))
 
         return await self._build_outputs(inst, service)
@@ -101,7 +103,8 @@ class Database(Resource[DatabaseConfig, DatabaseOutputs]):
 
     async def _delete(self, config: DatabaseConfig) -> None:
         """Delete database from instance. Idempotent: succeeds if not found."""
-        inst = config.instance.config
+        instance_resource = await config.instance.resolve()
+        inst = instance_resource.config
         service = get_sqladmin_service(get_credentials(inst.credentials))
 
         await execute(

--- a/packages/gcp/src/gcp_provider/resources/cloudsql/user.py
+++ b/packages/gcp/src/gcp_provider/resources/cloudsql/user.py
@@ -54,7 +54,8 @@ class User(Resource[UserConfig, UserOutputs]):
 
         Idempotent: If user already exists, returns its current state.
         """
-        inst = self.config.instance.config
+        instance_resource = await self.config.instance.resolve()
+        inst = instance_resource.config
         service = get_sqladmin_service(get_credentials(inst.credentials))
 
         await execute(
@@ -93,7 +94,8 @@ class User(Resource[UserConfig, UserOutputs]):
             await self._delete(previous_config)
             return await self.on_create()
 
-        inst = self.config.instance.config
+        instance_resource = await self.config.instance.resolve()
+        inst = instance_resource.config
         service = get_sqladmin_service(get_credentials(inst.credentials))
 
         if previous_config.password != self.config.password:
@@ -127,7 +129,8 @@ class User(Resource[UserConfig, UserOutputs]):
 
     async def _delete(self, config: UserConfig) -> None:
         """Delete user from instance. Idempotent: succeeds if not found."""
-        inst = config.instance.config
+        instance_resource = await config.instance.resolve()
+        inst = instance_resource.config
         service = get_sqladmin_service(get_credentials(inst.credentials))
 
         await execute(


### PR DESCRIPTION
## Summary
- Call `await self.config.instance.resolve()` to get the resolved resource before accessing its config
- `Dependency` objects don't have a direct `config` attribute - `resolve()` returns the full typed resource instance
- Applied to `cloudsql/database` and `cloudsql/user` resources

## Test plan
- [ ] Deploy provider after SDK v0.17.1 is published
- [ ] E2E test database and user creation with Cloud SQL instance dependency

Fixes PRA-169

**Note:** Requires pragma-sdk PR to be merged and published first.