### PR TITLE
fix(agno): runtime dependencies and import fix

### DIFF
--- a/packages/agno/pyproject.toml
+++ b/packages/agno/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "agno[anthropic,openai,postgres,qdrant]>=2.4.0",
     "sqlalchemy>=2.0.0",
     "mcp>=1.26.0",
+    "ddgs>=8.0.0",
 ]
 
 authors = [
@@ -19,7 +20,6 @@ authors = [
 
 [dependency-groups]
 dev = [
-    "ddgs>=8.0.0",
     "psycopg[binary]>=3.0.0",
     "pytest>=8.4.1",
     "pytest-asyncio>=1.0.0",

--- a/packages/agno/src/agno_provider/resources/memory/manager.py
+++ b/packages/agno/src/agno_provider/resources/memory/manager.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
 from agno.memory.manager import MemoryManager as AgnoMemoryManager
 from pragma_sdk import Config, Dependency, Outputs
@@ -13,15 +13,11 @@ from agno_provider.resources.models.anthropic import (
     AnthropicModelOutputs,
     AnthropicModelSpec,
 )
-from agno_provider.resources.models.base import model_from_spec
+from agno_provider.resources.models.base import Model, model_from_spec
 from agno_provider.resources.models.openai import (
     OpenAIModelOutputs,
     OpenAIModelSpec,
 )
-
-
-if TYPE_CHECKING:
-    from agno_provider.resources.models.base import Model
 
 
 class MemoryManagerSpec(AgnoSpec):


### PR DESCRIPTION
## Summary
- Move `ddgs` from dev to main dependencies (needed at runtime for DuckDuckGo search)
- Fix `Model` import in memory manager (Pydantic schema generation requires runtime access)

## Context
Discovered during end-to-end testing of Agno agent deployment:

1. **ddgs ImportError**: Agent tools use DuckDuckGo search (`ddgs`) but it was only in dev dependencies
2. **PydanticUserError**: The `Model` type was imported under `TYPE_CHECKING`, but Pydantic needs it at runtime to generate proper JSON schemas for the dependency union type

## Dependencies
This PR should be merged **after** [pragma-os#27](https://github.com/pragmatiks/pragma-os/pull/27) (union type dependency support).

## Test plan
- [ ] Rebuild agno provider image
- [ ] Deploy provider to cluster
- [ ] Create agent resource with MemoryManager
- [ ] Verify agent initializes without import errors

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed two critical runtime errors discovered during end-to-end testing of Agno agent deployment.

**Changes:**
- Moved `ddgs>=8.0.0` from dev dependencies to runtime dependencies in `pyproject.toml` - the DuckDuckGo search library is required at runtime by `agno.tools.websearch.WebSearchTools`, not just for development/testing
- Removed `TYPE_CHECKING` guard around `Model` import in `manager.py` - Pydantic requires the `Model` type at runtime to generate proper JSON schemas for the `Dependency[Model]` union type used in `MemoryManagerConfig.model`

Both fixes address import errors that would occur in production when agents are deployed and attempt to initialize with MemoryManager or WebSearch tools.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - both changes are straightforward dependency fixes
- Both changes correctly address runtime dependency issues: moving `ddgs` to runtime dependencies is necessary since it's imported by production code, and removing TYPE_CHECKING for Model is required for Pydantic schema generation
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agno/pyproject.toml | Moved `ddgs>=8.0.0` from dev to runtime dependencies to fix ImportError in production |
| packages/agno/src/agno_provider/resources/memory/manager.py | Removed TYPE_CHECKING guard for `Model` import to enable runtime Pydantic schema generation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Deploy as Deployment
    participant Agent as Agent Resource
    participant Memory as MemoryManager
    participant Tools as WebSearch Tools
    participant Pydantic as Pydantic Validator
    
    Deploy->>Agent: Initialize with MemoryManager + WebSearch
    
    Agent->>Memory: Create MemoryManager resource
    Memory->>Pydantic: Validate MemoryManagerConfig
    Note over Pydantic: Requires Model type at runtime<br/>for Dependency[Model] union
    Pydantic-->>Memory: Schema validated
    Memory->>Memory: _build_spec()
    Memory-->>Agent: MemoryManagerOutputs with spec
    
    Agent->>Tools: Create WebSearch toolkit
    Tools->>Tools: Import WebSearchTools from agno
    Note over Tools: agno.tools.websearch requires ddgs<br/>at runtime (not just dev)
    Tools-->>Agent: Toolkit with pip_dependencies
    
    Agent->>Agent: from_spec() - Runtime reconstruction
    Agent->>Memory: MemoryManager.from_spec(spec)
    Memory->>Memory: Instantiate AgnoMemoryManager
    Agent->>Tools: ToolsWebSearch.from_spec(spec)
    Tools->>Tools: Instantiate WebSearchTools
    Note over Tools: ddgs must be installed in runtime env
    
    Agent-->>Deploy: Agent initialized successfully
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->