### PR TITLE
Add description attribute to all Resource classes

### DIFF
--- a/packages/agno/src/agno_provider/resources/agent.py
+++ b/packages/agno/src/agno_provider/resources/agent.py
@@ -181,6 +181,7 @@ class Agent(AgnoResource[AgentConfig, AgentOutputs, AgentSpec]):
 
     provider: ClassVar[str] = "agno"
     resource: ClassVar[str] = "agent"
+    description = "Defines an AI agent with model, tools, and memory."
 
     @staticmethod
     def from_spec(spec: AgentSpec) -> AgnoAgent:

--- a/packages/agno/src/agno_provider/resources/db/postgres.py
+++ b/packages/agno/src/agno_provider/resources/db/postgres.py
@@ -185,6 +185,7 @@ class DbPostgres(AgnoResource[DbPostgresConfig, DbPostgresOutputs, DbPostgresSpe
 
     provider: ClassVar[str] = "agno"
     resource: ClassVar[str] = "db/postgres"
+    description = "Configures a PostgreSQL database for agent storage."
 
     @staticmethod
     def from_spec(spec: DbPostgresSpec) -> AsyncPostgresDb:

--- a/packages/agno/src/agno_provider/resources/knowledge/content.py
+++ b/packages/agno/src/agno_provider/resources/knowledge/content.py
@@ -134,6 +134,7 @@ class Content(AgnoResource[ContentConfig, ContentOutputs, ContentSpec]):
 
     provider: ClassVar[str] = "agno"
     resource: ClassVar[str] = "knowledge/content"
+    description = "Ingests content into a knowledge base."
 
     async def _resolve_knowledge(self) -> AgnoKnowledge:
         """Resolve knowledge dependency and return Agno Knowledge instance.

--- a/packages/agno/src/agno_provider/resources/knowledge/embedder/openai.py
+++ b/packages/agno/src/agno_provider/resources/knowledge/embedder/openai.py
@@ -93,6 +93,7 @@ class EmbedderOpenAI(AgnoResource[EmbedderOpenAIConfig, EmbedderOpenAIOutputs, E
 
     provider: ClassVar[str] = "agno"
     resource: ClassVar[str] = "knowledge/embedder/openai"
+    description = "Configures an OpenAI embedding model."
 
     @staticmethod
     def from_spec(spec: EmbedderOpenAISpec) -> OpenAIEmbedder:

--- a/packages/agno/src/agno_provider/resources/knowledge/knowledge.py
+++ b/packages/agno/src/agno_provider/resources/knowledge/knowledge.py
@@ -97,6 +97,7 @@ class Knowledge(AgnoResource[KnowledgeConfig, KnowledgeOutputs, KnowledgeSpec]):
 
     provider: ClassVar[str] = "agno"
     resource: ClassVar[str] = "knowledge"
+    description = "Configures a knowledge base for semantic search."
 
     @staticmethod
     def from_spec(spec: KnowledgeSpec) -> AgnoKnowledge:

--- a/packages/agno/src/agno_provider/resources/memory/manager.py
+++ b/packages/agno/src/agno_provider/resources/memory/manager.py
@@ -111,6 +111,7 @@ class MemoryManager(AgnoResource[MemoryManagerConfig, MemoryManagerOutputs, Memo
 
     provider: ClassVar[str] = "agno"
     resource: ClassVar[str] = "memory/manager"
+    description = "Configures persistent memory for AI agents."
 
     @staticmethod
     def from_spec(spec: MemoryManagerSpec) -> AgnoMemoryManager:

--- a/packages/agno/src/agno_provider/resources/models/anthropic.py
+++ b/packages/agno/src/agno_provider/resources/models/anthropic.py
@@ -88,6 +88,7 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
     """
 
     resource: ClassVar[str] = "models/anthropic"
+    description = "Configures an Anthropic Claude language model."
 
     @staticmethod
     def from_spec(spec: AnthropicModelSpec) -> Claude:

--- a/packages/agno/src/agno_provider/resources/models/openai.py
+++ b/packages/agno/src/agno_provider/resources/models/openai.py
@@ -115,6 +115,7 @@ class OpenAIModel(Model[OpenAIModelConfig, OpenAIModelOutputs, OpenAIModelSpec, 
     """
 
     resource: ClassVar[str] = "models/openai"
+    description = "Configures an OpenAI language model."
 
     @staticmethod
     def from_spec(spec: OpenAIModelSpec) -> OpenAIChat:

--- a/packages/agno/src/agno_provider/resources/prompt.py
+++ b/packages/agno/src/agno_provider/resources/prompt.py
@@ -99,6 +99,7 @@ class Prompt(AgnoResource[PromptConfig, PromptOutputs, PromptSpec]):
 
     provider: ClassVar[str] = "agno"
     resource: ClassVar[str] = "prompt"
+    description = "Defines a reusable prompt template with variables."
 
     @staticmethod
     def from_spec(spec: PromptSpec) -> str:

--- a/packages/agno/src/agno_provider/resources/runner.py
+++ b/packages/agno/src/agno_provider/resources/runner.py
@@ -176,6 +176,7 @@ class Runner(Resource[RunnerConfig, RunnerOutputs]):
 
     provider: ClassVar[str] = "agno"
     resource: ClassVar[str] = "runner"
+    description = "Deploys an AI agent or team to Kubernetes."
 
     def _runner_name(self) -> str:
         """Get Kubernetes deployment name based on resource name.

--- a/packages/agno/src/agno_provider/resources/team.py
+++ b/packages/agno/src/agno_provider/resources/team.py
@@ -221,6 +221,7 @@ class Team(AgnoResource[TeamConfig, TeamOutputs, TeamSpec]):
 
     provider: ClassVar[str] = "agno"
     resource: ClassVar[str] = "team"
+    description = "Defines a team of AI agents with coordinated workflows."
 
     @staticmethod
     def from_spec(spec: TeamSpec) -> AgnoTeam:

--- a/packages/agno/src/agno_provider/resources/tools/mcp.py
+++ b/packages/agno/src/agno_provider/resources/tools/mcp.py
@@ -124,6 +124,7 @@ class ToolsMCP(AgnoResource[ToolsMCPConfig, ToolsMCPOutputs, ToolsMCPSpec]):
 
     provider: ClassVar[str] = "agno"
     resource: ClassVar[str] = "tools/mcp"
+    description = "Integrates an MCP server as agent tools."
 
     @staticmethod
     def from_spec(spec: ToolsMCPSpec) -> MCPTools:

--- a/packages/agno/src/agno_provider/resources/tools/websearch.py
+++ b/packages/agno/src/agno_provider/resources/tools/websearch.py
@@ -91,6 +91,7 @@ class ToolsWebSearch(AgnoResource[ToolsWebSearchConfig, ToolsWebSearchOutputs, T
 
     provider: ClassVar[str] = "agno"
     resource: ClassVar[str] = "tools/websearch"
+    description = "Provides web search capabilities to agents."
 
     @staticmethod
     def from_spec(spec: ToolsWebSearchSpec) -> WebSearchTools:

--- a/packages/agno/src/agno_provider/resources/vectordb/qdrant.py
+++ b/packages/agno/src/agno_provider/resources/vectordb/qdrant.py
@@ -117,6 +117,7 @@ class VectordbQdrant(AgnoResource[VectordbQdrantConfig, VectordbQdrantOutputs, V
 
     provider: ClassVar[str] = "agno"
     resource: ClassVar[str] = "vectordb/qdrant"
+    description = "Configures a Qdrant vector store for knowledge bases."
 
     @staticmethod
     def from_spec(spec: VectordbQdrantSpec) -> Qdrant:

--- a/packages/gcp/src/gcp_provider/resources/cloudsql/database.py
+++ b/packages/gcp/src/gcp_provider/resources/cloudsql/database.py
@@ -89,6 +89,7 @@ class Database(Resource[DatabaseConfig, DatabaseOutputs]):
 
     provider: ClassVar[str] = "gcp"
     resource: ClassVar[str] = "cloudsql/database"
+    description = "Manages databases within a Cloud SQL instance."
 
     async def on_create(self) -> DatabaseOutputs:
         """Create database in the Cloud SQL instance.

--- a/packages/gcp/src/gcp_provider/resources/cloudsql/database_instance.py
+++ b/packages/gcp/src/gcp_provider/resources/cloudsql/database_instance.py
@@ -205,6 +205,7 @@ class DatabaseInstance(Resource[DatabaseInstanceConfig, DatabaseInstanceOutputs]
 
     provider: ClassVar[str] = "gcp"
     resource: ClassVar[str] = "cloudsql/database_instance"
+    description = "Manages Google Cloud SQL database instances."
 
     async def on_create(self) -> DatabaseInstanceOutputs:
         """Create Cloud SQL instance and wait for RUNNABLE state.

--- a/packages/gcp/src/gcp_provider/resources/cloudsql/user.py
+++ b/packages/gcp/src/gcp_provider/resources/cloudsql/user.py
@@ -79,6 +79,7 @@ class User(Resource[UserConfig, UserOutputs]):
 
     provider: ClassVar[str] = "gcp"
     resource: ClassVar[str] = "cloudsql/user"
+    description = "Manages database users within a Cloud SQL instance."
 
     async def on_create(self) -> UserOutputs:
         """Create user in the Cloud SQL instance.

--- a/packages/gcp/src/gcp_provider/resources/gke.py
+++ b/packages/gcp/src/gcp_provider/resources/gke.py
@@ -202,6 +202,7 @@ class GKE(Resource[GKEConfig, GKEOutputs]):
 
     provider: ClassVar[str] = "gcp"
     resource: ClassVar[str] = "gke"
+    description = "Manages Google Kubernetes Engine clusters."
 
     def _get_client(self) -> ClusterManagerAsyncClient:
         """Get Cluster Manager async client with user-provided credentials.

--- a/packages/gcp/src/gcp_provider/resources/secret.py
+++ b/packages/gcp/src/gcp_provider/resources/secret.py
@@ -95,6 +95,7 @@ class Secret(Resource[SecretConfig, SecretOutputs]):
 
     provider: ClassVar[str] = "gcp"
     resource: ClassVar[str] = "secret"
+    description = "Manages secrets in Google Cloud Secret Manager."
 
     def _get_client(self) -> SecretManagerServiceAsyncClient:
         """Get Secret Manager async client with user-provided credentials.

--- a/packages/kubernetes/src/kubernetes_provider/resources/configmap.py
+++ b/packages/kubernetes/src/kubernetes_provider/resources/configmap.py
@@ -62,6 +62,7 @@ class ConfigMap(Resource[ConfigMapConfig, ConfigMapOutputs]):
 
     provider: ClassVar[str] = "kubernetes"
     resource: ClassVar[str] = "configmap"
+    description = "Manages Kubernetes config maps for application configuration."
 
     @asynccontextmanager
     async def _get_client(self):

--- a/packages/kubernetes/src/kubernetes_provider/resources/deployment.py
+++ b/packages/kubernetes/src/kubernetes_provider/resources/deployment.py
@@ -213,6 +213,7 @@ class Deployment(Resource[DeploymentConfig, DeploymentOutputs]):
 
     provider: ClassVar[str] = "kubernetes"
     resource: ClassVar[str] = "deployment"
+    description = "Manages Kubernetes deployments for stateless workloads."
 
     @asynccontextmanager
     async def _get_client(self):

--- a/packages/kubernetes/src/kubernetes_provider/resources/namespace.py
+++ b/packages/kubernetes/src/kubernetes_provider/resources/namespace.py
@@ -58,6 +58,7 @@ class Namespace(Resource[NamespaceConfig, NamespaceOutputs]):
 
     provider: ClassVar[str] = "kubernetes"
     resource: ClassVar[str] = "namespace"
+    description = "Manages Kubernetes namespaces for workload isolation."
 
     @asynccontextmanager
     async def _get_client(self):

--- a/packages/kubernetes/src/kubernetes_provider/resources/secret.py
+++ b/packages/kubernetes/src/kubernetes_provider/resources/secret.py
@@ -70,6 +70,7 @@ class Secret(Resource[SecretConfig, SecretOutputs]):
 
     provider: ClassVar[str] = "kubernetes"
     resource: ClassVar[str] = "secret"
+    description = "Manages Kubernetes secrets for sensitive data."
 
     @asynccontextmanager
     async def _get_client(self):

--- a/packages/kubernetes/src/kubernetes_provider/resources/service.py
+++ b/packages/kubernetes/src/kubernetes_provider/resources/service.py
@@ -100,6 +100,7 @@ class Service(Resource[ServiceConfig, ServiceOutputs]):
 
     provider: ClassVar[str] = "kubernetes"
     resource: ClassVar[str] = "service"
+    description = "Manages Kubernetes services for network access to pods."
 
     @asynccontextmanager
     async def _get_client(self):

--- a/packages/kubernetes/src/kubernetes_provider/resources/statefulset.py
+++ b/packages/kubernetes/src/kubernetes_provider/resources/statefulset.py
@@ -255,6 +255,7 @@ class StatefulSet(Resource[StatefulSetConfig, StatefulSetOutputs]):
 
     provider: ClassVar[str] = "kubernetes"
     resource: ClassVar[str] = "statefulset"
+    description = "Manages Kubernetes stateful sets with persistent storage."
 
     @asynccontextmanager
     async def _get_client(self):

--- a/packages/qdrant/src/qdrant_provider/resources/collection.py
+++ b/packages/qdrant/src/qdrant_provider/resources/collection.py
@@ -76,6 +76,7 @@ class Collection(Resource[CollectionConfig, CollectionOutputs]):
 
     provider: ClassVar[str] = "qdrant"
     resource: ClassVar[str] = "collection"
+    description = "Manages Qdrant vector collections for similarity search."
 
     def _get_client(self) -> AsyncQdrantClient:
         """Get Qdrant async client with configured credentials.

--- a/packages/qdrant/src/qdrant_provider/resources/database.py
+++ b/packages/qdrant/src/qdrant_provider/resources/database.py
@@ -132,6 +132,7 @@ class Database(Resource[DatabaseConfig, DatabaseOutputs]):
 
     provider: ClassVar[str] = "qdrant"
     resource: ClassVar[str] = "database"
+    description = "Deploys a Qdrant vector database to Kubernetes."
 
     _resolved_api_key: str | None = None
 


### PR DESCRIPTION
## Summary
- Adds explicit `description` class attributes to all 27 Resource subclasses across GCP (5), Kubernetes (6), Qdrant (2), and Agno (14) providers
- Uses the SDK's `Resource.description` ClassVar field, which flows into `extract_schemas()` for the platform store
- Each description is a concise, human-readable sentence (~10-15 words) describing what the resource manages

## Test plan
- [x] All tests pass across all 4 providers (378 total: 39 GCP + 54 Kubernetes + 35 Qdrant + 250 Agno)
- [x] Ruff lint and format checks pass
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added human-readable descriptions to resource classes across agno, gcp, kubernetes, and qdrant modules to improve API documentation and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->