### PR TITLE
fix(agno): mark api_key fields as SensitiveField (PRA-309)

### DIFF
--- a/packages/agno/src/agno_provider/resources/models/anthropic.py
+++ b/packages/agno/src/agno_provider/resources/models/anthropic.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Literal
 
 from agno.models.anthropic import Claude
-from pragma_sdk import Field
+from pragma_sdk import Field, SensitiveField
 
 from agno_provider.resources.base import AgnoSpec
 from agno_provider.resources.models.base import Model, ModelConfig, ModelOutputs
@@ -52,7 +52,7 @@ class AnthropicModelConfig(ModelConfig):
         stop_sequences: Stop sequences to end generation. Optional.
     """
 
-    api_key: Field[str]
+    api_key: SensitiveField[str]
     max_tokens: Field[int] = 8192
     temperature: Field[float] | None = None
     top_p: Field[float] | None = None

--- a/packages/agno/src/agno_provider/resources/models/openai.py
+++ b/packages/agno/src/agno_provider/resources/models/openai.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Literal
 
 from agno.models.openai import OpenAIChat
-from pragma_sdk import Field
+from pragma_sdk import Field, SensitiveField
 
 from agno_provider.resources.base import AgnoSpec
 from agno_provider.resources.models.base import Model, ModelConfig, ModelOutputs
@@ -77,7 +77,7 @@ class OpenAIModelConfig(ModelConfig):
         base_url: Optional custom base URL for OpenAI-compatible APIs.
     """
 
-    api_key: Field[str]
+    api_key: SensitiveField[str]
     max_tokens: Field[int] | None = None
     temperature: Field[float] | None = None
     top_p: Field[float] | None = None


### PR DESCRIPTION
## Summary

- Change `api_key: Field[str]` to `api_key: SensitiveField[str]` in OpenAI and Anthropic model configs
- Ensures `resolved_config` in API responses shows `"********"` instead of raw API keys
- No API or SDK changes needed — masking infrastructure already exists

## Test plan

- [x] 237 agno tests passing
- [x] Ruff lint clean