### PR TITLE
feat(agno): multi-entity AgentOS support on runner

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -761,6 +761,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      packages: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -879,3 +880,49 @@ jobs:
         run: |
           cd packages/agno
           pragma providers publish --version "${{ steps.bump.outputs.version }}" --org pragmatiks
+
+      - name: Read runner transport version
+        id: runner-transport
+        run: |
+          TRANSPORT=$(grep -E '^LABEL ai\.pragmatiks\.agno-runner\.transport=' packages/agno/runner/Dockerfile \
+            | sed -E 's/.*transport="([^"]+)".*/\1/')
+          if [ -z "$TRANSPORT" ]; then
+            echo "Failed to parse agno-runner transport version from Dockerfile"
+            exit 1
+          fi
+          echo "transport=$TRANSPORT" >> "$GITHUB_OUTPUT"
+          echo "Runner transport version: $TRANSPORT"
+
+      - name: Resolve provider version for image label
+        id: runner-provider-version
+        run: |
+          cd packages/agno
+          VERSION="${{ steps.bump.outputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION=$(cz version --project)
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Provider version for image: $VERSION"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push agno runner image
+        uses: docker/build-push-action@v6
+        with:
+          context: packages/agno
+          file: packages/agno/runner/Dockerfile
+          push: true
+          platforms: linux/amd64
+          build-args: |
+            PROVIDER_VERSION=${{ steps.runner-provider-version.outputs.version }}
+          tags: |
+            ghcr.io/pragmatiks/agno-runner:${{ steps.runner-transport.outputs.transport }}
+            ghcr.io/pragmatiks/agno-runner:latest

--- a/packages/agno/README.md
+++ b/packages/agno/README.md
@@ -28,8 +28,8 @@ namespace (kubernetes) ─────┘
 
 1. Configuration resources (models, tools, knowledge, etc.) resolve their dependencies and produce a serializable `Spec`
 2. The `agent` or `team` resource aggregates all specs from its dependencies into a single `AgentSpec` or `TeamSpec`
-3. The `runner` resource deploys the agent/team to Kubernetes by passing the spec as JSON environment variables
-4. The container image reconstructs the full agent/team from the spec at startup using `from_spec()` factory methods
+3. The `runner` resource deploys one or more agents and teams to Kubernetes by passing the combined specs as a JSON environment variable
+4. The container image reconstructs every agent/team from the spec payload at startup using `from_spec()` factory methods and registers them with a single AgentOS instance
 5. When any dependency changes (e.g., a model API key rotates), Pragma propagates the change through the dependency graph and redeploys automatically
 
 ## Prerequisites
@@ -37,7 +37,7 @@ namespace (kubernetes) ─────┘
 - A `kubernetes/config` resource providing cluster access (in-cluster, a GKE cluster, or an external kubeconfig)
 - A Kubernetes namespace managed by the `kubernetes` provider
 - API keys for your chosen model provider (OpenAI, Anthropic)
-- An Agno runner container image (default: `ghcr.io/pragmatiks/agno-runner:latest`)
+- An Agno runner container image (default: `ghcr.io/pragmatiks/agno-runner:v2`)
 - For knowledge/RAG: a Qdrant vector database instance
 - For memory/sessions: a PostgreSQL database instance
 
@@ -53,7 +53,7 @@ pragma providers install agno
 |----------|-----------|-------------|
 | Agent | `agent` | AI agent definition with model, tools, knowledge, and memory |
 | Team | `team` | Coordinated group of agents with shared resources |
-| Runner | `runner` | Deploys an agent or team to Kubernetes as a Deployment + Service |
+| Runner | `runner` | Deploys one or more agents/teams to Kubernetes as a Deployment + Service |
 | Prompt | `prompt` | Reusable instruction template with variable interpolation |
 | OpenAI Model | `models/openai` | OpenAI model configuration (GPT-4o, etc.) |
 | Anthropic Model | `models/anthropic` | Anthropic model configuration (Claude, etc.) |
@@ -218,8 +218,8 @@ provider: agno
 resource: runner
 name: support-agent
 config:
-  agent:
-    ref: agno/agent/support-agent
+  agents:
+    - ref: agno/agent/support-agent
   config:
     ref: kubernetes/config/main-cluster
   namespace:
@@ -278,8 +278,8 @@ provider: agno
 resource: runner
 name: content-team
 config:
-  team:
-    ref: agno/team/content-team
+  teams:
+    - ref: agno/team/content-team
   config:
     ref: kubernetes/config/main-cluster
   namespace:

--- a/packages/agno/runner/Dockerfile
+++ b/packages/agno/runner/Dockerfile
@@ -1,14 +1,23 @@
 # Agno runner container image.
 #
-# Serves an Agno agent or team as an HTTP API using AgentOS.
-# The agent/team is reconstructed from spec JSON passed via environment variables.
+# Serves one or more Agno agents, teams, and workflows as an HTTP API using
+# a single AgentOS instance. Entities are reconstructed at startup from the
+# AGNO_SPECS_JSON environment variable.
+#
+# This image is tagged with a major version (v2, v3, ...) that matches the
+# transport contract expected by the agno provider's Runner resource. The
+# wire format is otherwise unversioned -- bump the tag whenever the env-var
+# contract changes and update the Runner default image in lockstep.
 #
 # Build from agno package root:
-#   docker build -f runner/Dockerfile -t ghcr.io/pragmatiks/agno-runner:latest .
+#   docker build -f runner/Dockerfile \
+#     -t ghcr.io/pragmatiks/agno-runner:v2 \
+#     -t ghcr.io/pragmatiks/agno-runner:latest .
 #
 # Optional: pass the current provider version so it is recorded as an image label:
 #   docker build -f runner/Dockerfile \
 #     --build-arg PROVIDER_VERSION="$(cz version --project)" \
+#     -t ghcr.io/pragmatiks/agno-runner:v2 \
 #     -t ghcr.io/pragmatiks/agno-runner:latest .
 
 FROM python:3.13-slim AS builder
@@ -38,7 +47,8 @@ LABEL org.opencontainers.image.title="pragma-agno-runner"
 LABEL org.opencontainers.image.description="Runtime container for Pragma agno agents and teams."
 LABEL org.opencontainers.image.source="https://github.com/pragmatiks/pragma-providers"
 LABEL org.opencontainers.image.version="${PROVIDER_VERSION}"
-LABEL ai.pragmatiks.agno-runner.features="output_schema"
+LABEL ai.pragmatiks.agno-runner.features="output_schema,multi_entity"
+LABEL ai.pragmatiks.agno-runner.transport="v2"
 
 # Node.js is needed for MCP tools that use npx
 RUN apt-get update && \

--- a/packages/agno/runner/server.py
+++ b/packages/agno/runner/server.py
@@ -1,11 +1,12 @@
-"""Agno runner server - reconstructs agent/team from spec and serves via AgentOS.
+"""Agno runner server - reconstructs agents, teams, and workflows from specs.
 
-Reads AGNO_SPEC_TYPE and AGNO_SPEC_JSON environment variables to reconstruct
-an Agno agent or team, then serves it as an HTTP API using AgentOS on port 8000.
+Reads the AGNO_SPECS_JSON environment variable to reconstruct one or more
+Agno agents and teams, then serves them as an HTTP API using a single
+AgentOS instance on port 8000.
 
 Environment variables:
-    AGNO_SPEC_TYPE: "agent" or "team"
-    AGNO_SPEC_JSON: JSON-serialized AgentSpec or TeamSpec
+    AGNO_SPECS_JSON: JSON payload with shape
+        {"agents": [<AgentSpec>...], "teams": [<TeamSpec>...], "workflows": []}
 """
 
 from __future__ import annotations
@@ -13,62 +14,97 @@ from __future__ import annotations
 import json
 import os
 import sys
+from typing import Any
 
 from agno_provider.resources.agent import Agent, AgentSpec
 from agno_provider.resources.team import Team, TeamSpec
 
 
-def build_app():
-    """Build the FastAPI app from environment variables.
+def _exit_with_error(message: str) -> None:
+    """Log an error to stderr and exit with status 1.
 
-    Reads AGNO_SPEC_TYPE and AGNO_SPEC_JSON, reconstructs the agent or team,
-    and wraps it in an AgentOS instance.
+    Args:
+        message: Human-readable error message for stderr.
+    """
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+def _parse_specs_payload(raw: str) -> tuple[list[AgentSpec], list[TeamSpec]]:
+    """Parse the AGNO_SPECS_JSON payload into typed spec lists.
+
+    Args:
+        raw: Raw JSON string from the AGNO_SPECS_JSON env var.
+
+    Returns:
+        Tuple of (agent_specs, team_specs) parsed from the payload.
+    """
+    payload: dict[str, Any] = json.loads(raw)
+
+    agent_dicts: list[dict[str, Any]] = payload.get("agents", []) or []
+    team_dicts: list[dict[str, Any]] = payload.get("teams", []) or []
+    workflow_dicts: list[dict[str, Any]] = payload.get("workflows", []) or []
+
+    if workflow_dicts:
+        _exit_with_error("AGNO_SPECS_JSON.workflows is reserved and must be empty in this runner image")
+
+    agent_specs = [AgentSpec.model_validate(item) for item in agent_dicts]
+    team_specs = [TeamSpec.model_validate(item) for item in team_dicts]
+
+    if not agent_specs and not team_specs:
+        _exit_with_error("AGNO_SPECS_JSON must include at least one agent or team spec")
+
+    return agent_specs, team_specs
+
+
+def _build_agent_os_name(agent_specs: list[AgentSpec], team_specs: list[TeamSpec]) -> str:
+    """Derive a stable AgentOS instance name from the first provided entity.
+
+    Args:
+        agent_specs: Parsed agent specs.
+        team_specs: Parsed team specs.
+
+    Returns:
+        Name string used by AgentOS for identification.
+    """
+    if agent_specs:
+        return agent_specs[0].name
+
+    return team_specs[0].name
+
+
+def build_app():  # noqa: ANN201
+    """Build the FastAPI app from the AGNO_SPECS_JSON environment variable.
+
+    Reconstructs every agent and team from the payload and registers all of
+    them with a single AgentOS instance.
 
     Returns:
         FastAPI application ready to serve.
     """
     from agno.os.app import AgentOS  # noqa: PLC0415
 
-    spec_type = os.environ.get("AGNO_SPEC_TYPE")
-    spec_json = os.environ.get("AGNO_SPEC_JSON")
+    specs_json = os.environ.get("AGNO_SPECS_JSON")
 
-    if not spec_type:
-        print("AGNO_SPEC_TYPE environment variable is required", file=sys.stderr)
-        sys.exit(1)
-
-    if not spec_json:
-        print("AGNO_SPEC_JSON environment variable is required", file=sys.stderr)
-        sys.exit(1)
+    if not specs_json:
+        _exit_with_error("AGNO_SPECS_JSON environment variable is required")
+        return None
 
     authorization = bool(os.environ.get("JWT_VERIFICATION_KEY"))
 
-    spec_data = json.loads(spec_json)
+    agent_specs, team_specs = _parse_specs_payload(specs_json)
 
-    if spec_type == "agent":
-        spec = AgentSpec.model_validate(spec_data)
-        agent = Agent.from_spec(spec)
+    agents = [Agent.from_spec(spec) for spec in agent_specs]
+    teams = [Team.from_spec(spec) for spec in team_specs]
 
-        agent_os = AgentOS(
-            name=spec.name,
-            agents=[agent],
-            authorization=authorization,
-            telemetry=False,
-        )
-
-    elif spec_type == "team":
-        spec = TeamSpec.model_validate(spec_data)
-        team = Team.from_spec(spec)
-
-        agent_os = AgentOS(
-            name=spec.name,
-            teams=[team],
-            authorization=authorization,
-            telemetry=False,
-        )
-
-    else:
-        print(f"AGNO_SPEC_TYPE must be 'agent' or 'team', got: {spec_type}", file=sys.stderr)
-        sys.exit(1)
+    agent_os = AgentOS(
+        name=_build_agent_os_name(agent_specs, team_specs),
+        agents=agents,
+        teams=teams,
+        workflows=[],
+        authorization=authorization,
+        telemetry=False,
+    )
 
     return agent_os.get_app()
 

--- a/packages/agno/runner/server.py
+++ b/packages/agno/runner/server.py
@@ -1,4 +1,4 @@
-"""Agno runner server - reconstructs agents, teams, and workflows from specs.
+"""Agno runner server - reconstructs agents and teams from specs.
 
 Reads the AGNO_SPECS_JSON environment variable to reconstruct one or more
 Agno agents and teams, then serves them as an HTTP API using a single
@@ -7,27 +7,76 @@ AgentOS instance on port 8000.
 Environment variables:
     AGNO_SPECS_JSON: JSON payload with shape
         {"agents": [<AgentSpec>...], "teams": [<TeamSpec>...], "workflows": []}
+        The ``workflows`` key is reserved and must be empty or absent.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
-from typing import Any
+from typing import Any, NoReturn
 
 from agno_provider.resources.agent import Agent, AgentSpec
 from agno_provider.resources.team import Team, TeamSpec
 
 
-def _exit_with_error(message: str) -> None:
-    """Log an error to stderr and exit with status 1.
+logger = logging.getLogger("agno_runner")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
+
+
+def _exit_with_error(message: str) -> NoReturn:
+    """Log a structured error and exit with status 1.
 
     Args:
-        message: Human-readable error message for stderr.
+        message: Human-readable error message describing what failed.
     """
-    print(message, file=sys.stderr)
+    logger.error("runner_startup_failed: %s", message)
+    print(f"runner_startup_failed: {message}", file=sys.stderr)
     sys.exit(1)
+
+
+def _load_specs_json(raw: str) -> dict[str, Any]:
+    """Decode the AGNO_SPECS_JSON string into a dict.
+
+    Args:
+        raw: Raw JSON payload from the AGNO_SPECS_JSON env var.
+
+    Returns:
+        Top-level dict with ``agents``/``teams``/``workflows`` keys.
+    """
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _exit_with_error(f"AGNO_SPECS_JSON is not valid JSON: {exc.msg} at line {exc.lineno} column {exc.colno}")
+
+    if not isinstance(payload, dict):
+        _exit_with_error(f"AGNO_SPECS_JSON must be a JSON object, got {type(payload).__name__}")
+
+    return payload
+
+
+def _extract_entity_dicts(payload: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    """Read a list of spec dicts from the payload, validating the shape.
+
+    Args:
+        payload: Parsed AGNO_SPECS_JSON payload.
+        key: Entity list key (e.g. ``"agents"``, ``"teams"``, ``"workflows"``).
+
+    Returns:
+        List of spec dicts, empty if the key is missing or null.
+    """
+    value = payload.get(key, []) or []
+
+    if not isinstance(value, list):
+        _exit_with_error(f"AGNO_SPECS_JSON.{key} must be a list, got {type(value).__name__}")
+
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            _exit_with_error(f"AGNO_SPECS_JSON.{key}[{index}] must be an object, got {type(item).__name__}")
+
+    return value
 
 
 def _parse_specs_payload(raw: str) -> tuple[list[AgentSpec], list[TeamSpec]]:
@@ -39,17 +88,32 @@ def _parse_specs_payload(raw: str) -> tuple[list[AgentSpec], list[TeamSpec]]:
     Returns:
         Tuple of (agent_specs, team_specs) parsed from the payload.
     """
-    payload: dict[str, Any] = json.loads(raw)
+    payload = _load_specs_json(raw)
 
-    agent_dicts: list[dict[str, Any]] = payload.get("agents", []) or []
-    team_dicts: list[dict[str, Any]] = payload.get("teams", []) or []
-    workflow_dicts: list[dict[str, Any]] = payload.get("workflows", []) or []
+    agent_dicts = _extract_entity_dicts(payload, "agents")
+    team_dicts = _extract_entity_dicts(payload, "teams")
+    workflow_dicts = _extract_entity_dicts(payload, "workflows")
 
     if workflow_dicts:
         _exit_with_error("AGNO_SPECS_JSON.workflows is reserved and must be empty in this runner image")
 
-    agent_specs = [AgentSpec.model_validate(item) for item in agent_dicts]
-    team_specs = [TeamSpec.model_validate(item) for item in team_dicts]
+    agent_specs: list[AgentSpec] = []
+    for index, item in enumerate(agent_dicts):
+        try:
+            agent_specs.append(AgentSpec.model_validate(item))
+        except Exception as exc:
+            name = item.get("name") if isinstance(item, dict) else None
+            label = f"name={name!r}" if name else f"index={index}"
+            _exit_with_error(f"AGNO_SPECS_JSON.agents[{index}] is not a valid AgentSpec ({label}): {exc}")
+
+    team_specs: list[TeamSpec] = []
+    for index, item in enumerate(team_dicts):
+        try:
+            team_specs.append(TeamSpec.model_validate(item))
+        except Exception as exc:
+            name = item.get("name") if isinstance(item, dict) else None
+            label = f"name={name!r}" if name else f"index={index}"
+            _exit_with_error(f"AGNO_SPECS_JSON.teams[{index}] is not a valid TeamSpec ({label}): {exc}")
 
     if not agent_specs and not team_specs:
         _exit_with_error("AGNO_SPECS_JSON must include at least one agent or team spec")
@@ -73,6 +137,36 @@ def _build_agent_os_name(agent_specs: list[AgentSpec], team_specs: list[TeamSpec
     return team_specs[0].name
 
 
+def _build_agent(spec: AgentSpec) -> Agent:
+    """Reconstruct a single Agent from its spec with a clear error surface.
+
+    Args:
+        spec: Parsed AgentSpec to hydrate.
+
+    Returns:
+        Fully-hydrated Agent instance.
+    """
+    try:
+        return Agent.from_spec(spec)
+    except Exception as exc:
+        _exit_with_error(f"failed to reconstruct agent name={spec.name!r}: {type(exc).__name__}: {exc}")
+
+
+def _build_team(spec: TeamSpec) -> Team:
+    """Reconstruct a single Team from its spec with a clear error surface.
+
+    Args:
+        spec: Parsed TeamSpec to hydrate.
+
+    Returns:
+        Fully-hydrated Team instance.
+    """
+    try:
+        return Team.from_spec(spec)
+    except Exception as exc:
+        _exit_with_error(f"failed to reconstruct team name={spec.name!r}: {type(exc).__name__}: {exc}")
+
+
 def build_app():  # noqa: ANN201
     """Build the FastAPI app from the AGNO_SPECS_JSON environment variable.
 
@@ -88,14 +182,13 @@ def build_app():  # noqa: ANN201
 
     if not specs_json:
         _exit_with_error("AGNO_SPECS_JSON environment variable is required")
-        return None
 
     authorization = bool(os.environ.get("JWT_VERIFICATION_KEY"))
 
     agent_specs, team_specs = _parse_specs_payload(specs_json)
 
-    agents = [Agent.from_spec(spec) for spec in agent_specs]
-    teams = [Team.from_spec(spec) for spec in team_specs]
+    agents = [_build_agent(spec) for spec in agent_specs]
+    teams = [_build_team(spec) for spec in team_specs]
 
     agent_os = AgentOS(
         name=_build_agent_os_name(agent_specs, team_specs),

--- a/packages/agno/src/agno_provider/resources/runner.py
+++ b/packages/agno/src/agno_provider/resources/runner.py
@@ -105,7 +105,7 @@ class RunnerConfig(Config):
     config: ImmutableDependency[KubernetesConfig]
     namespace: Dependency[Namespace]
     replicas: Field[int] = 1
-    image: Field[str] = "ghcr.io/pragmatiks/agno-runner:latest"
+    image: Field[str] = "ghcr.io/pragmatiks/agno-runner:v2"
     security_key: Field[str] | None = None
     jwt_verification_key: Field[str] | None = None
     public: Field[bool] = False

--- a/packages/agno/src/agno_provider/resources/runner.py
+++ b/packages/agno/src/agno_provider/resources/runner.py
@@ -1,4 +1,9 @@
-"""Agno Runner resource - deploys agents, teams, and workflows to Kubernetes."""
+"""Agno Runner resource - deploys agents and teams to Kubernetes.
+
+A Runner hosts one or more agents and teams on a single AgentOS instance.
+The ``workflows`` field is reserved; it will be populated once a dedicated
+Workflow resource type ships and must stay empty in the meantime.
+"""
 
 from __future__ import annotations
 
@@ -73,15 +78,17 @@ def _find_duplicates(names: list[str]) -> list[str]:
 class RunnerSpec(AgnoSpec):
     """Specification for reconstructing a Runner configuration.
 
-    Contains all runner configuration including the nested agent, team, and
-    workflow specs. Used for tracking what was deployed.
+    Contains all runner configuration including the nested agent and team
+    specs. Used for tracking what was deployed.
 
     Attributes:
         name: Runner name (Kubernetes deployment name).
         namespace: Kubernetes namespace where the runner is deployed.
         agent_specs: Nested agent specs deployed on this runner.
         team_specs: Nested team specs deployed on this runner.
-        workflow_specs: Nested workflow specs deployed on this runner.
+        workflow_specs: Reserved for a future Workflow resource type. Kept in
+            the spec schema for forward compatibility and always serialized as
+            an empty list today.
         replicas: Number of pod replicas.
         image: Container image used for the runner pods.
         cpu: CPU resource request.
@@ -102,20 +109,22 @@ class RunnerSpec(AgnoSpec):
 
 
 class RunnerConfig(Config):
-    """Configuration for deploying Agno agents, teams, and workflows to Kubernetes.
+    """Configuration for deploying Agno agents and teams to Kubernetes.
 
-    A single runner can host multiple agents, teams, and workflows in one
-    AgentOS instance. At least one entity across the three lists is required.
+    A single runner can host multiple agents and teams in one AgentOS
+    instance. At least one agent or team is required. The ``workflows``
+    field is reserved and must be left empty until the Workflow resource
+    type ships; runtime validation rejects any non-empty value.
 
     Attributes:
         agents: Agent dependencies to deploy on this runner.
         teams: Team dependencies to deploy on this runner.
-        workflows: Workflow dependencies to deploy on this runner. Must be empty
-            in v1; reserved for when the Workflow resource type is introduced.
+        workflows: Reserved for a future Workflow resource type. Must be
+            empty; populating it is rejected by the config validator.
         config: Kubernetes config dependency providing cluster access.
         namespace: Kubernetes namespace dependency for the runner pods.
         replicas: Number of pod replicas. Defaults to 1.
-        image: Container image for running the agents/teams/workflows.
+        image: Container image for running the agents and teams.
         security_key: Bearer token for AgentOS basic auth (dev environments).
         jwt_verification_key: Public key for JWT/RBAC auth (production environments).
         public: Expose the service via LoadBalancer instead of ClusterIP. Defaults to False.
@@ -218,14 +227,17 @@ class Runner(Resource[RunnerConfig, RunnerOutputs]):
     """Agno multi-entity runner on Kubernetes.
 
     This is the ONLY agno resource that creates infrastructure. It deploys
-    one or more agents, teams, and workflows into a single AgentOS instance
-    served by a Kubernetes Deployment + Service using child kubernetes
-    provider resources.
+    one or more agents and teams into a single AgentOS instance served by a
+    Kubernetes Deployment + Service using child kubernetes provider
+    resources.
 
     The container receives the combined entity specs as a single JSON
     environment variable:
 
     - AGNO_SPECS_JSON: ``{"agents": [<AgentSpec>...], "teams": [<TeamSpec>...], "workflows": []}``
+
+    The ``workflows`` key is always emitted as an empty list until a
+    dedicated Workflow resource type ships.
 
     The container image uses the payload to reconstruct each entity at startup
     and register all of them with a single AgentOS instance.

--- a/packages/agno/src/agno_provider/resources/runner.py
+++ b/packages/agno/src/agno_provider/resources/runner.py
@@ -1,10 +1,10 @@
-"""Agno Runner resource - deploys agents or teams to Kubernetes."""
+"""Agno Runner resource - deploys agents, teams, and workflows to Kubernetes."""
 
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from datetime import datetime
-from typing import Literal
+from typing import Any
 
 from kubernetes_provider import (
     Deployment as KubernetesDeployment,
@@ -47,14 +47,15 @@ from agno_provider.resources.team import Team, TeamOutputs, TeamSpec
 class RunnerSpec(AgnoSpec):
     """Specification for reconstructing a Runner configuration.
 
-    Contains all runner configuration including the nested agent or team spec.
-    Used for tracking what was deployed.
+    Contains all runner configuration including the nested agent, team, and
+    workflow specs. Used for tracking what was deployed.
 
     Attributes:
         name: Runner name (Kubernetes deployment name).
         namespace: Kubernetes namespace where the runner is deployed.
-        agent_spec: Nested agent spec if deploying a single agent.
-        team_spec: Nested team spec if deploying a team.
+        agent_specs: Nested agent specs deployed on this runner.
+        team_specs: Nested team specs deployed on this runner.
+        workflow_specs: Nested workflow specs deployed on this runner.
         replicas: Number of pod replicas.
         image: Container image used for the runner pods.
         cpu: CPU resource request.
@@ -64,8 +65,9 @@ class RunnerSpec(AgnoSpec):
 
     name: str
     namespace: str
-    agent_spec: AgentSpec | None = None
-    team_spec: TeamSpec | None = None
+    agent_specs: list[AgentSpec] = []
+    team_specs: list[TeamSpec] = []
+    workflow_specs: list[Any] = []
     replicas: int
     image: str
     cpu: str
@@ -74,17 +76,20 @@ class RunnerSpec(AgnoSpec):
 
 
 class RunnerConfig(Config):
-    """Configuration for deploying an Agno agent or team to Kubernetes.
+    """Configuration for deploying Agno agents, teams, and workflows to Kubernetes.
 
-    Exactly one of agent or team must be provided.
+    A single runner can host multiple agents, teams, and workflows in one
+    AgentOS instance. At least one entity across the three lists is required.
 
     Attributes:
-        agent: Agent dependency to deploy. Mutually exclusive with team.
-        team: Team dependency to deploy. Mutually exclusive with agent.
+        agents: Agent dependencies to deploy on this runner.
+        teams: Team dependencies to deploy on this runner.
+        workflows: Workflow dependencies to deploy on this runner. Must be empty
+            in v1; reserved for when the Workflow resource type is introduced.
         config: Kubernetes config dependency providing cluster access.
         namespace: Kubernetes namespace dependency for the runner pods.
         replicas: Number of pod replicas. Defaults to 1.
-        image: Container image for running the agent/team.
+        image: Container image for running the agents/teams/workflows.
         security_key: Bearer token for AgentOS basic auth (dev environments).
         jwt_verification_key: Public key for JWT/RBAC auth (production environments).
         public: Expose the service via LoadBalancer instead of ClusterIP. Defaults to False.
@@ -92,8 +97,9 @@ class RunnerConfig(Config):
         memory: Memory resource request and limit (e.g., "1Gi", "2Gi"). Defaults to "1Gi".
     """
 
-    agent: Dependency[Agent] | None = None
-    team: Dependency[Team] | None = None
+    agents: list[Dependency[Agent]] = []
+    teams: list[Dependency[Team]] = []
+    workflows: list[Any] = []
 
     config: ImmutableDependency[KubernetesConfig]
     namespace: Dependency[Namespace]
@@ -107,24 +113,26 @@ class RunnerConfig(Config):
     memory: Field[str] = "1Gi"
 
     @model_validator(mode="after")
-    def validate_exactly_one_target(self) -> RunnerConfig:
-        """Validate that exactly one of agent or team is provided.
+    def validate_at_least_one_entity(self) -> RunnerConfig:
+        """Validate that at least one agent, team, or workflow is provided.
 
         Returns:
             Self after validation.
 
         Raises:
-            ValueError: If neither or both of agent and team are provided.
+            ValueError: If no entities are provided, or if workflows is non-empty
+                (the Workflow resource type is not yet implemented).
         """
-        has_agent = self.agent is not None
-        has_team = self.team is not None
-
-        if not has_agent and not has_team:
-            msg = "Either agent or team must be provided"
+        if self.workflows:
+            msg = (
+                "workflows is reserved for a future release; pass an empty "
+                "list until the Workflow resource type is introduced"
+            )
             raise ValueError(msg)
 
-        if has_agent and has_team:
-            msg = "Only one of agent or team can be provided, not both"
+        total = len(self.agents) + len(self.teams) + len(self.workflows)
+        if total < 1:
+            msg = "At least one agent, team, or workflow must be provided"
             raise ValueError(msg)
 
         return self
@@ -145,27 +153,26 @@ class RunnerOutputs(Outputs):
 
 
 class Runner(Resource[RunnerConfig, RunnerOutputs]):
-    """Agno agent/team runner on Kubernetes.
+    """Agno multi-entity runner on Kubernetes.
 
     This is the ONLY agno resource that creates infrastructure. It deploys
-    either an agent or a team as a Kubernetes Deployment + Service using
-    child kubernetes provider resources.
+    one or more agents, teams, and workflows into a single AgentOS instance
+    served by a Kubernetes Deployment + Service using child kubernetes
+    provider resources.
 
-    The container receives the agent/team spec as JSON environment variables:
-    - AGNO_SPEC_TYPE: "agent" or "team"
-    - AGNO_SPEC_JSON: JSON-serialized AgentSpec or TeamSpec
-
-    The container image uses these to reconstruct the agent/team at startup.
+    The container receives entity specs as JSON environment variables. The
+    transport contract is versioned with the container image; see the runner
+    package for the current wire format.
 
     Example YAML:
         provider: agno
         resource: runner
         name: my-agent-runner
         config:
-          agent:
-            provider: agno
-            resource: agent
-            name: my-agent
+          agents:
+            - provider: agno
+              resource: agent
+              name: my-agent
           config:
             provider: kubernetes
             resource: config
@@ -231,60 +238,72 @@ class Runner(Resource[RunnerConfig, RunnerOutputs]):
 
         return ns.outputs.name
 
-    async def _get_spec_info(self) -> tuple[Literal["agent", "team"], AgentSpec | TeamSpec]:
-        """Get spec type and spec from resolved dependency.
+    async def _resolve_entity_specs(self) -> tuple[list[AgentSpec], list[TeamSpec]]:
+        """Resolve every agent and team dependency into their specs.
 
         Returns:
-            Tuple of (spec_type, spec).
+            Tuple of (agent_specs, team_specs) in declaration order.
 
         Raises:
-            RuntimeError: If dependency outputs are not available.
+            RuntimeError: If any dependency outputs are not available.
         """
-        if self.config.agent is not None:
-            agent = await self.config.agent.resolve()
+        agent_specs: list[AgentSpec] = []
+        for agent_dep in self.config.agents:
+            agent = await agent_dep.resolve()
 
             if agent.outputs is None:
                 msg = "Agent dependency outputs not available"
                 raise RuntimeError(msg)
 
             assert isinstance(agent.outputs, AgentOutputs)
-            return ("agent", agent.outputs.spec)
+            agent_specs.append(agent.outputs.spec)
 
-        if self.config.team is not None:
-            team = await self.config.team.resolve()
+        team_specs: list[TeamSpec] = []
+        for team_dep in self.config.teams:
+            team = await team_dep.resolve()
 
             if team.outputs is None:
                 msg = "Team dependency outputs not available"
                 raise RuntimeError(msg)
 
             assert isinstance(team.outputs, TeamOutputs)
-            return ("team", team.outputs.spec)
+            team_specs.append(team.outputs.spec)
 
-        msg = "Neither agent nor team dependency is set"
-        raise RuntimeError(msg)
+        return agent_specs, team_specs
 
     def _build_kubernetes_deployment(
         self,
         namespace_name: str,
-        spec_type: Literal["agent", "team"],
-        spec: AgentSpec | TeamSpec,
+        agent_specs: list[AgentSpec],
+        team_specs: list[TeamSpec],
     ) -> KubernetesDeployment:
         """Build kubernetes/deployment child resource.
 
         Args:
             namespace_name: Resolved namespace name string.
-            spec_type: Type of spec ("agent" or "team").
-            spec: The agent or team spec to deploy.
+            agent_specs: Agent specs to deploy on this runner.
+            team_specs: Team specs to deploy on this runner.
 
         Returns:
             Kubernetes Deployment resource ready to apply.
+
+        Raises:
+            RuntimeError: If both agent_specs and team_specs are empty.
         """
         labels = self._labels()
-        spec_json = spec.model_dump_json()
+
+        primary_spec: AgentSpec | TeamSpec | None = (
+            agent_specs[0] if agent_specs else (team_specs[0] if team_specs else None)
+        )
+        primary_type = "agent" if agent_specs else "team"
+
+        if primary_spec is None:
+            msg = "Runner requires at least one agent or team spec"
+            raise RuntimeError(msg)
 
         env = {
-            "AGNO_SPEC_TYPE": spec_type,
-            "AGNO_SPEC_JSON": spec_json,
+            "AGNO_SPEC_TYPE": primary_type,
+            "AGNO_SPEC_JSON": primary_spec.model_dump_json(),
         }
 
         if self.config.security_key:
@@ -414,14 +433,16 @@ class Runner(Resource[RunnerConfig, RunnerOutputs]):
     def _build_outputs(
         self,
         namespace_name: str,
-        spec: AgentSpec | TeamSpec,
+        agent_specs: list[AgentSpec],
+        team_specs: list[TeamSpec],
         ready: bool,
     ) -> RunnerOutputs:
         """Build runner outputs.
 
         Args:
             namespace_name: Resolved namespace name string.
-            spec: The agent or team spec deployed.
+            agent_specs: Agent specs deployed on this runner.
+            team_specs: Team specs deployed on this runner.
             ready: Whether runner is ready.
 
         Returns:
@@ -430,8 +451,9 @@ class Runner(Resource[RunnerConfig, RunnerOutputs]):
         runner_spec = RunnerSpec(
             name=self._runner_name(),
             namespace=namespace_name,
-            agent_spec=spec if isinstance(spec, AgentSpec) else None,
-            team_spec=spec if isinstance(spec, TeamSpec) else None,
+            agent_specs=agent_specs,
+            team_specs=team_specs,
+            workflow_specs=[],
             replicas=self.config.replicas,
             image=self.config.image,
             cpu=self.config.cpu,
@@ -448,17 +470,17 @@ class Runner(Resource[RunnerConfig, RunnerOutputs]):
     async def _apply_kubernetes_resources(
         self,
         namespace_name: str,
-        spec_type: Literal["agent", "team"],
-        spec: AgentSpec | TeamSpec,
+        agent_specs: list[AgentSpec],
+        team_specs: list[TeamSpec],
     ) -> None:
         """Apply kubernetes deployment and service as child resources.
 
         Args:
             namespace_name: Resolved namespace name string.
-            spec_type: Type of spec ("agent" or "team").
-            spec: The agent or team spec to deploy.
+            agent_specs: Agent specs to deploy on this runner.
+            team_specs: Team specs to deploy on this runner.
         """
-        kubernetes_deployment = self._build_kubernetes_deployment(namespace_name, spec_type, spec)
+        kubernetes_deployment = self._build_kubernetes_deployment(namespace_name, agent_specs, team_specs)
         await kubernetes_deployment.apply()
 
         kubernetes_service = self._build_kubernetes_service(namespace_name)
@@ -468,12 +490,12 @@ class Runner(Resource[RunnerConfig, RunnerOutputs]):
         """Get kubernetes deployment resource for current spec.
 
         Returns:
-            Kubernetes Deployment resource configured for current agent/team.
+            Kubernetes Deployment resource configured for current entities.
         """
         namespace_name = await self._resolve_namespace_name()
-        spec_type, spec = await self._get_spec_info()
+        agent_specs, team_specs = await self._resolve_entity_specs()
 
-        return self._build_kubernetes_deployment(namespace_name, spec_type, spec)
+        return self._build_kubernetes_deployment(namespace_name, agent_specs, team_specs)
 
     async def on_create(self) -> RunnerOutputs:
         """Create Kubernetes Deployment + Service.
@@ -482,11 +504,11 @@ class Runner(Resource[RunnerConfig, RunnerOutputs]):
             RunnerOutputs with runner details.
         """
         namespace_name = await self._resolve_namespace_name()
-        spec_type, spec = await self._get_spec_info()
+        agent_specs, team_specs = await self._resolve_entity_specs()
 
-        await self._apply_kubernetes_resources(namespace_name, spec_type, spec)
+        await self._apply_kubernetes_resources(namespace_name, agent_specs, team_specs)
 
-        return self._build_outputs(namespace_name, spec, ready=True)
+        return self._build_outputs(namespace_name, agent_specs, team_specs, ready=True)
 
     async def on_update(self, previous_config: RunnerConfig) -> RunnerOutputs:
         """Update Kubernetes Deployment + Service.
@@ -509,11 +531,11 @@ class Runner(Resource[RunnerConfig, RunnerOutputs]):
             raise ValueError(msg)
 
         namespace_name = await self._resolve_namespace_name()
-        spec_type, spec = await self._get_spec_info()
+        agent_specs, team_specs = await self._resolve_entity_specs()
 
-        await self._apply_kubernetes_resources(namespace_name, spec_type, spec)
+        await self._apply_kubernetes_resources(namespace_name, agent_specs, team_specs)
 
-        return self._build_outputs(namespace_name, spec, ready=True)
+        return self._build_outputs(namespace_name, agent_specs, team_specs, ready=True)
 
     async def on_delete(self) -> None:
         """Delete Kubernetes Deployment + Service.

--- a/packages/agno/src/agno_provider/resources/runner.py
+++ b/packages/agno/src/agno_provider/resources/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any
@@ -43,6 +44,30 @@ from pydantic import model_validator
 from agno_provider.resources.agent import Agent, AgentOutputs, AgentSpec
 from agno_provider.resources.base import AgnoSpec
 from agno_provider.resources.team import Team, TeamOutputs, TeamSpec
+
+
+logger = logging.getLogger(__name__)
+
+
+def _find_duplicates(names: list[str]) -> list[str]:
+    """Return names that appear more than once, in order of first repeat.
+
+    Args:
+        names: Candidate names to scan for duplicates.
+
+    Returns:
+        Sorted list of names that appear two or more times.
+    """
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+
+    for name in names:
+        if name in seen:
+            duplicates.add(name)
+        else:
+            seen.add(name)
+
+    return sorted(duplicates)
 
 
 class RunnerSpec(AgnoSpec):
@@ -115,7 +140,7 @@ class RunnerConfig(Config):
 
     @model_validator(mode="after")
     def validate_at_least_one_entity(self) -> RunnerConfig:
-        """Validate that at least one agent, team, or workflow is provided.
+        """Validate that at least one agent or team is provided.
 
         Returns:
             Self after validation.
@@ -131,10 +156,46 @@ class RunnerConfig(Config):
             )
             raise ValueError(msg)
 
-        total = len(self.agents) + len(self.teams) + len(self.workflows)
+        total = len(self.agents) + len(self.teams)
         if total < 1:
-            msg = "At least one agent, team, or workflow must be provided"
+            msg = "At least one agent or team must be provided"
             raise ValueError(msg)
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_unique_entity_names(self) -> RunnerConfig:
+        """Validate that agent and team names are unique within their own list.
+
+        Two agents or two teams sharing the same name cause AgentOS to raise a
+        ValueError at startup. An agent sharing a name with a team is merely
+        confusing in routing and is warned about, not rejected.
+
+        Returns:
+            Self after validation.
+
+        Raises:
+            ValueError: If two agents or two teams share a name.
+        """
+        agent_names = [dep.name for dep in self.agents]
+        team_names = [dep.name for dep in self.teams]
+
+        duplicate_agents = _find_duplicates(agent_names)
+        if duplicate_agents:
+            msg = f"Duplicate agent names on runner: {', '.join(duplicate_agents)}"
+            raise ValueError(msg)
+
+        duplicate_teams = _find_duplicates(team_names)
+        if duplicate_teams:
+            msg = f"Duplicate team names on runner: {', '.join(duplicate_teams)}"
+            raise ValueError(msg)
+
+        shared = sorted(set(agent_names) & set(team_names))
+        if shared:
+            logger.warning(
+                "Runner has entities sharing names across agents and teams: %s",
+                ", ".join(shared),
+            )
 
         return self
 

--- a/packages/agno/src/agno_provider/resources/runner.py
+++ b/packages/agno/src/agno_provider/resources/runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any
@@ -160,9 +161,13 @@ class Runner(Resource[RunnerConfig, RunnerOutputs]):
     served by a Kubernetes Deployment + Service using child kubernetes
     provider resources.
 
-    The container receives entity specs as JSON environment variables. The
-    transport contract is versioned with the container image; see the runner
-    package for the current wire format.
+    The container receives the combined entity specs as a single JSON
+    environment variable:
+
+    - AGNO_SPECS_JSON: ``{"agents": [<AgentSpec>...], "teams": [<TeamSpec>...], "workflows": []}``
+
+    The container image uses the payload to reconstruct each entity at startup
+    and register all of them with a single AgentOS instance.
 
     Example YAML:
         provider: agno
@@ -292,18 +297,18 @@ class Runner(Resource[RunnerConfig, RunnerOutputs]):
         """
         labels = self._labels()
 
-        primary_spec: AgentSpec | TeamSpec | None = (
-            agent_specs[0] if agent_specs else (team_specs[0] if team_specs else None)
-        )
-        primary_type = "agent" if agent_specs else "team"
-
-        if primary_spec is None:
+        if not agent_specs and not team_specs:
             msg = "Runner requires at least one agent or team spec"
             raise RuntimeError(msg)
 
+        specs_payload = {
+            "agents": [spec.model_dump(mode="json") for spec in agent_specs],
+            "teams": [spec.model_dump(mode="json") for spec in team_specs],
+            "workflows": [],
+        }
+
         env = {
-            "AGNO_SPEC_TYPE": primary_type,
-            "AGNO_SPEC_JSON": primary_spec.model_dump_json(),
+            "AGNO_SPECS_JSON": json.dumps(specs_payload),
         }
 
         if self.config.security_key:


### PR DESCRIPTION
## Summary
- Replace the singular `agent` / `team` fields on `RunnerConfig` (and mirrored `RunnerSpec`) with `agents`, `teams`, and `workflows` lists so one runner can host several entities under a single AgentOS instance. `workflows` is wired through the plumbing but validation rejects non-empty values until the Workflow resource type lands.
- Switch the container transport from `AGNO_SPEC_TYPE` + `AGNO_SPEC_JSON` to a single `AGNO_SPECS_JSON` payload (`{"agents": [...], "teams": [...], "workflows": []}`) that matches `AgentOS(agents=..., teams=..., workflows=...)`.
- Update `runner/server.py` to parse the combined payload, reconstruct every entity via `Agent.from_spec` / `Team.from_spec`, and register them all against a single AgentOS. Bump the default runner image to `ghcr.io/pragmatiks/agno-runner:v2` and add `transport=v2` / `multi_entity` feature labels to the Dockerfile.

Closes [PRA-344](https://linear.app/pragmatiks/issue/PRA-344).

## Test plan
- [ ] `task agno:check` (ruff clean; ty baseline unchanged at 141 diagnostics across the repo)
- [ ] Rebuild `ghcr.io/pragmatiks/agno-runner:v2` from `packages/agno/runner/Dockerfile` and verify `docker inspect` shows the new labels
- [ ] Deploy a runner with two agents + one team and confirm all three appear in AgentOS' `/agents` and `/teams` endpoints
- [ ] Deploy a single-agent runner to confirm backward compatibility for the common case
- [ ] Reject a runner config with non-empty `workflows` at apply time