### PR TITLE
chore(pragma): bump version to 1.0.1

### DIFF
--- a/packages/pragma/CHANGELOG.md
+++ b/packages/pragma/CHANGELOG.md
@@ -1,3 +1,9 @@
+## pragma-v1.0.1 (2026-04-18)
+
+### Fix
+
+- Republish to land an up-to-date provider version in the platform catalog.
+
 ## pragma-v1.0.0 (2026-04-18)
 
 ### Feat

--- a/packages/pragma/pyproject.toml
+++ b/packages/pragma/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pragmatiks-pragma-provider"
-version = "1.0.0"
+version = "1.0.1"
 description = "Built-in platform provider for Pragmatiks"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -36,7 +36,7 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.0.0"
+version = "1.0.1"
 version_files = ["pyproject.toml:^version"]
 tag_format = "pragma-v$version"
 update_changelog_on_bump = true

--- a/packages/pragma/uv.lock
+++ b/packages/pragma/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "pragmatiks-pragma-provider"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "obstore" },


### PR DESCRIPTION
## Summary

Bumps `pragmatiks-pragma-provider` from `1.0.0` to `1.0.1`.

PRA-351 part 1 (the move of the pragma provider to the public publish pipeline) merged as `99a330e` and published v1.0.0 to PyPI. However, the pragma-os API catalog already had a `provider_versions` row for `pragmatiks/pragma v1.0.0` created back in March by the legacy `register_platform_resources` startup path. When CI republished v1.0.0 from the new public pipeline, catalog idempotency returned success without updating the row — so the catalog still points at the old Helm image URL, not a freshly-built image from the new publish pipeline.

Bumping to v1.0.1 forces the catalog to create a brand new row via the new pipeline, which is required before dispatching pragma-os Part 2 (which relies on `provider_engine.install("pragmatiks/pragma", ...)` pulling a valid PyPI-built image from the catalog).

Changes:
- `packages/pragma/pyproject.toml`: `[project].version` and `[tool.commitizen].version` both bumped to `1.0.1`
- `packages/pragma/CHANGELOG.md`: new `pragma-v1.0.1` entry prepended
- `packages/pragma/uv.lock`: refreshed

Refs: PRA-351

## Test plan

- [x] `task pragma:test` — 15 passed, 96% coverage
- [x] `uv run ruff check .` — all checks passed
- [x] `task pragma:format` — clean
- [x] `uv build` — produces `pragmatiks_pragma_provider-1.0.1-py3-none-any.whl`
- [x] CHANGELOG header `pragma-v1.0.1` matches `tag_format` in pyproject.toml
- [ ] CI publish cascade runs a fresh build, catalog creates new row for v1.0.1