### PR TITLE
feat(agno): honest readiness for runner + credential validation

### DIFF
--- a/packages/agno/pyproject.toml
+++ b/packages/agno/pyproject.toml
@@ -5,7 +5,7 @@ description = "Agno agent provider for Pragmatiks"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pragmatiks-sdk>=0.34.0",
+    "pragmatiks-sdk>=1.2.0",
     "pragmatiks-gcp-provider>=0.77.0",
     "pragmatiks-kubernetes-provider>=0.100.0",
     "agno[anthropic,openai,postgres,qdrant]>=2.4.0",

--- a/packages/agno/src/agno_provider/resources/models/anthropic.py
+++ b/packages/agno/src/agno_provider/resources/models/anthropic.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
+import anthropic
 from agno.models.anthropic import Claude
 from pragma_sdk import Field, SensitiveField
 
@@ -77,8 +78,10 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
     parameters. The Claude instance is created via from_spec() at runtime.
 
     This is a thin wrapper - the Claude instance is created on-demand.
-    No API validation is performed since the Agno SDK handles authentication
-    when the model is actually used.
+    On create, the API key and model id are validated against the Anthropic
+    API via ``client.models.retrieve``. Invalid credentials or a missing
+    model id surface as a FAILED resource rather than silently succeeding
+    and breaking on first agent invocation.
 
     Runtime reconstruction from spec:
         ```python
@@ -127,12 +130,28 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
         return AnthropicModelOutputs(spec=self._build_spec())
 
     async def on_create(self) -> AnthropicModelOutputs:
-        """Create returns serializable outputs with spec.
+        """Validate credentials against Anthropic and return outputs with spec.
+
+        Performs a lightweight ``client.models.retrieve`` round-trip so an
+        invalid API key or nonexistent model id fails the resource at
+        create time rather than on first agent invocation. Any error from
+        the Anthropic SDK propagates so the runtime marks the resource
+        FAILED.
 
         Returns:
             AnthropicModelOutputs with spec.
         """
+        await self._validate_credentials()
         return self._build_outputs()
+
+    async def _validate_credentials(self) -> None:
+        """Round-trip to Anthropic to verify the API key and model id.
+
+        Any error from the Anthropic SDK propagates so the runtime marks
+        the resource FAILED.
+        """
+        client = anthropic.AsyncAnthropic(api_key=str(self.config.api_key))
+        await client.models.retrieve(self.config.id)
 
     async def on_update(self, previous_config: AnthropicModelConfig) -> AnthropicModelOutputs:  # noqa: ARG002
         """Update returns serializable outputs with spec.

--- a/packages/agno/src/agno_provider/resources/runner.py
+++ b/packages/agno/src/agno_provider/resources/runner.py
@@ -553,13 +553,17 @@ class Runner(Resource[RunnerConfig, RunnerOutputs]):
     ) -> None:
         """Apply kubernetes deployment and service as child resources.
 
+        The deployment is awaited until READY so the runner only reports
+        ready when pods have actually started. The service is applied
+        fire-and-forget because it does not gate pod readiness.
+
         Args:
             namespace_name: Resolved namespace name string.
             agent_specs: Agent specs to deploy on this runner.
             team_specs: Team specs to deploy on this runner.
         """
         kubernetes_deployment = self._build_kubernetes_deployment(namespace_name, agent_specs, team_specs)
-        await kubernetes_deployment.apply()
+        await kubernetes_deployment.apply(wait=True, timeout=300.0)
 
         kubernetes_service = self._build_kubernetes_service(namespace_name)
         await kubernetes_service.apply()

--- a/packages/agno/uv.lock
+++ b/packages/agno/uv.lock
@@ -1357,7 +1357,7 @@ wheels = [
 
 [[package]]
 name = "pragmatiks-agno-provider"
-version = "0.113.0"
+version = "0.117.0"
 source = { editable = "." }
 dependencies = [
     { name = "agno", extra = ["anthropic", "openai", "postgres", "qdrant"] },
@@ -1388,7 +1388,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "pragmatiks-gcp-provider", specifier = ">=0.77.0" },
     { name = "pragmatiks-kubernetes-provider", specifier = ">=0.100.0" },
-    { name = "pragmatiks-sdk", specifier = ">=0.34.0" },
+    { name = "pragmatiks-sdk", specifier = ">=1.2.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
 ]
@@ -1437,7 +1437,7 @@ wheels = [
 
 [[package]]
 name = "pragmatiks-sdk"
-version = "0.34.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1445,9 +1445,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/2c/a9752bc12408f750dd326c4eef2cafa499ae8cdc6137ff4bef85a1b77656/pragmatiks_sdk-0.34.0.tar.gz", hash = "sha256:8ec692eca09b0f2c2df56c5b6418047958da66f75c264bddf71f5744981cf224", size = 33607, upload-time = "2026-04-03T15:55:00.708Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/fc/113b34d695938410fdb133b2c8732b0ca227fea2bda8aa5b2052df86cab7/pragmatiks_sdk-1.2.0.tar.gz", hash = "sha256:a1ba9126be12f91d78114cb66936dec3a5004b029a72c1c351dd91e66a00f6de", size = 50175, upload-time = "2026-04-20T11:32:27.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/82/8c09c86e8c7c10f868c22ab333456ad61a52a29b0a8933a7bf3af6481999/pragmatiks_sdk-0.34.0-py3-none-any.whl", hash = "sha256:e80efcd47bd7fcce5df6127da0a73a667462ac3e00f7f28343313d49e2db946f", size = 41486, upload-time = "2026-04-03T15:54:59.564Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/98/132c11f49a13dc6f5bfc085047c3a40daad6e22063b52ee2987c1a75bbb3/pragmatiks_sdk-1.2.0-py3-none-any.whl", hash = "sha256:f6aefeb900e098dd237eb785471b63485168e0f84627c0cad0fdbd9bdd6e4fbd", size = 60030, upload-time = "2026-04-20T11:32:25.954Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes two sources of false-READY state in the agno provider, per PRA-357 plan sections A2 and A3.

**A2 — runner waits for child deployment readiness.** Previously the runner reported `ready=True` as soon as the kubernetes/deployment apply request was accepted. Pod failures (CrashLoopBackOff, ImagePullBackOff) happened after the runner transitioned to READY, so the bootstrap flow saw READY while the pods were still being scheduled or failing. The runner now calls `apply(wait=True, timeout=300.0)` on the deployment child and lets any failure or timeout propagate. The service stays fire-and-forget since it does not gate pod readiness.

**A3 — anthropic model validates at create.** `AnthropicModel.on_create` previously accepted any api key and model id without verification. A typo during bootstrap seeded a broken platform stack that reported READY but failed on first agent invocation. `on_create` now round-trips to the Anthropic API via `client.models.retrieve(model_id)` so invalid credentials or a missing model id raise at resource create time and mark the resource FAILED.

**Dependency:** bumps `pragmatiks-sdk` to `>=1.2.0` for the new `apply(wait=..., timeout=...)` kwarg. `anthropic` ships transitively via `agno[anthropic]` so no new dependency is added.

Refs PRA-357. Part of the "honest READY" effort — the API-side bootstrap wait (plan section A4) lands in a separate pragma-os PR.

## Test plan

- [x] `task agno:test` passes (empty suite — no new tests per project policy)
- [x] `task agno:check` ruff passes (ty baseline unchanged in nature — only new diagnostics are the same pre-existing `unresolved-import` class seen across the provider)
- [x] Modified files parse cleanly
- [ ] Live bootstrap smoke test with corrupted `ANTHROPIC_API_KEY` should produce FAILED on anthropic model (deferred to integration testing after merge)
- [ ] Live bootstrap smoke test with deployment killed mid-create should produce FAILED on runner (deferred to integration testing after merge)