### PR TITLE
fix(agno): remove workflows placeholder field to satisfy sdk type validation

### DIFF
--- a/packages/agno/src/agno_provider/resources/runner.py
+++ b/packages/agno/src/agno_provider/resources/runner.py
@@ -1,8 +1,6 @@
 """Agno Runner resource - deploys agents and teams to Kubernetes.
 
 A Runner hosts one or more agents and teams on a single AgentOS instance.
-The ``workflows`` field is reserved; it will be populated once a dedicated
-Workflow resource type ships and must stay empty in the meantime.
 """
 
 from __future__ import annotations
@@ -112,15 +110,11 @@ class RunnerConfig(Config):
     """Configuration for deploying Agno agents and teams to Kubernetes.
 
     A single runner can host multiple agents and teams in one AgentOS
-    instance. At least one agent or team is required. The ``workflows``
-    field is reserved and must be left empty until the Workflow resource
-    type ships; runtime validation rejects any non-empty value.
+    instance. At least one agent or team is required.
 
     Attributes:
         agents: Agent dependencies to deploy on this runner.
         teams: Team dependencies to deploy on this runner.
-        workflows: Reserved for a future Workflow resource type. Must be
-            empty; populating it is rejected by the config validator.
         config: Kubernetes config dependency providing cluster access.
         namespace: Kubernetes namespace dependency for the runner pods.
         replicas: Number of pod replicas. Defaults to 1.
@@ -134,7 +128,6 @@ class RunnerConfig(Config):
 
     agents: list[Dependency[Agent]] = []
     teams: list[Dependency[Team]] = []
-    workflows: list[Any] = []
 
     config: ImmutableDependency[KubernetesConfig]
     namespace: Dependency[Namespace]
@@ -155,16 +148,8 @@ class RunnerConfig(Config):
             Self after validation.
 
         Raises:
-            ValueError: If no entities are provided, or if workflows is non-empty
-                (the Workflow resource type is not yet implemented).
+            ValueError: If no entities are provided.
         """
-        if self.workflows:
-            msg = (
-                "workflows is reserved for a future release; pass an empty "
-                "list until the Workflow resource type is introduced"
-            )
-            raise ValueError(msg)
-
         total = len(self.agents) + len(self.teams)
         if total < 1:
             msg = "At least one agent or team must be provided"


### PR DESCRIPTION
## Summary

- Remove the bare-typed `workflows: list[Any]` field from `RunnerConfig`, which broke schema extraction in the `publish-agno` Cloud Build step under SDK 1.2.0's stricter `__pydantic_init_subclass__` validator.
- Remove the dead `self.workflows` branch in `validate_at_least_one_entity` and the associated docstring entries (module, class, validator).
- No speculative future-proofing: there is no `Workflow` resource type anywhere in the agno provider. Per project policy (no backward-compat / speculative scaffolding during beta), drop the placeholder entirely rather than adapt it to `Field[list[Any]]`.

`RunnerSpec.workflow_specs` is untouched — it is a `BaseModel`, not a `Config`, and is not subject to the validator. The `AGNO_SPECS_JSON` runner protocol still emits an empty `"workflows": []` key for the image.

## Context

Failing build: `a89e1a5b-434a-4bee-8781-e61417b12997` (publish-agno v0.119.0).

Error:
```
TypeError: Config field 'workflows' on RunnerConfig must use Field[T], ImmutableField[T],
SensitiveField[T], ImmutableSensitiveField[T], Dependency[T], ImmutableDependency[T],
or SensitiveDependency[T] — bare types are not allowed
```

Agno is the last provider blocking the cascade — every other tier already republished against SDK 1.2.0.

## Test plan

- [x] `task agno:format` — clean
- [x] `ruff check` — passes
- [x] `python -c "from agno_provider.resources.runner import RunnerConfig"` — SDK subclass validator now accepts the class
- [ ] CI `publish-agno` job publishes v0.119.1 successfully