### PR TITLE
feat(ci): migrate provider publish to ConsoleMachine + /console publish endpoint (PRA-369)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -105,9 +105,6 @@ jobs:
       - name: Install commitizen
         run: uv tool install commitizen
 
-      - name: Install pragma CLI
-        run: uv tool install pragmatiks-cli
-
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
@@ -164,10 +161,12 @@ jobs:
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
-          PRAGMA_AUTH_TOKEN: ${{ secrets.PRAGMA_AUTH_TOKEN }}
+          PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
         run: |
-          cd packages/gcp
-          pragma providers publish --version "${{ steps.bump.outputs.version }}" --org platform
+          ./scripts/publish_platform_provider.sh \
+            gcp \
+            "dist/pragmatiks_gcp_provider-${{ steps.bump.outputs.version }}.tar.gz" \
+            "${{ steps.bump.outputs.version }}"
 
   publish-supabase:
     needs: [detect-changes]
@@ -206,9 +205,6 @@ jobs:
 
       - name: Install commitizen
         run: uv tool install commitizen
-
-      - name: Install pragma CLI
-        run: uv tool install pragmatiks-cli
 
       - name: Configure git
         run: |
@@ -266,10 +262,12 @@ jobs:
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
-          PRAGMA_AUTH_TOKEN: ${{ secrets.PRAGMA_AUTH_TOKEN }}
+          PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
         run: |
-          cd packages/supabase
-          pragma providers publish --version "${{ steps.bump.outputs.version }}" --org platform
+          ./scripts/publish_platform_provider.sh \
+            supabase \
+            "dist/pragmatiks_supabase_provider-${{ steps.bump.outputs.version }}.tar.gz" \
+            "${{ steps.bump.outputs.version }}"
 
   publish-vercel:
     needs: [detect-changes]
@@ -308,9 +306,6 @@ jobs:
 
       - name: Install commitizen
         run: uv tool install commitizen
-
-      - name: Install pragma CLI
-        run: uv tool install pragmatiks-cli
 
       - name: Configure git
         run: |
@@ -368,10 +363,12 @@ jobs:
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
-          PRAGMA_AUTH_TOKEN: ${{ secrets.PRAGMA_AUTH_TOKEN }}
+          PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
         run: |
-          cd packages/vercel
-          pragma providers publish --version "${{ steps.bump.outputs.version }}" --org platform
+          ./scripts/publish_platform_provider.sh \
+            vercel \
+            "dist/pragmatiks_vercel_provider-${{ steps.bump.outputs.version }}.tar.gz" \
+            "${{ steps.bump.outputs.version }}"
 
   publish-github:
     needs: [detect-changes]
@@ -410,9 +407,6 @@ jobs:
 
       - name: Install commitizen
         run: uv tool install commitizen
-
-      - name: Install pragma CLI
-        run: uv tool install pragmatiks-cli
 
       - name: Configure git
         run: |
@@ -470,10 +464,12 @@ jobs:
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
-          PRAGMA_AUTH_TOKEN: ${{ secrets.PRAGMA_AUTH_TOKEN }}
+          PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
         run: |
-          cd packages/github
-          pragma providers publish --version "${{ steps.bump.outputs.version }}" --org platform
+          ./scripts/publish_platform_provider.sh \
+            github \
+            "dist/pragmatiks_github_provider-${{ steps.bump.outputs.version }}.tar.gz" \
+            "${{ steps.bump.outputs.version }}"
 
   publish-pragma:
     needs: [detect-changes]
@@ -512,9 +508,6 @@ jobs:
 
       - name: Install commitizen
         run: uv tool install commitizen
-
-      - name: Install pragma CLI
-        run: uv tool install pragmatiks-cli
 
       - name: Configure git
         run: |
@@ -572,10 +565,12 @@ jobs:
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
-          PRAGMA_AUTH_TOKEN: ${{ secrets.PRAGMA_AUTH_TOKEN }}
+          PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
         run: |
-          cd packages/pragma
-          pragma providers publish --version "${{ steps.bump.outputs.version }}" --org platform
+          ./scripts/publish_platform_provider.sh \
+            pragma \
+            "dist/pragmatiks_pragma_provider-${{ steps.bump.outputs.version }}.tar.gz" \
+            "${{ steps.bump.outputs.version }}"
 
   publish-kubernetes:
     needs: [detect-changes, publish-gcp]
@@ -629,9 +624,6 @@ jobs:
 
       - name: Install commitizen
         run: uv tool install commitizen
-
-      - name: Install pragma CLI
-        run: uv tool install pragmatiks-cli
 
       - name: Configure git
         run: |
@@ -706,10 +698,12 @@ jobs:
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
-          PRAGMA_AUTH_TOKEN: ${{ secrets.PRAGMA_AUTH_TOKEN }}
+          PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
         run: |
-          cd packages/kubernetes
-          pragma providers publish --version "${{ steps.bump.outputs.version }}" --org platform
+          ./scripts/publish_platform_provider.sh \
+            kubernetes \
+            "dist/pragmatiks_kubernetes_provider-${{ steps.bump.outputs.version }}.tar.gz" \
+            "${{ steps.bump.outputs.version }}"
 
   publish-qdrant:
     needs: [detect-changes, publish-kubernetes]
@@ -762,9 +756,6 @@ jobs:
 
       - name: Install commitizen
         run: uv tool install commitizen
-
-      - name: Install pragma CLI
-        run: uv tool install pragmatiks-cli
 
       - name: Configure git
         run: |
@@ -839,10 +830,12 @@ jobs:
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
-          PRAGMA_AUTH_TOKEN: ${{ secrets.PRAGMA_AUTH_TOKEN }}
+          PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
         run: |
-          cd packages/qdrant
-          pragma providers publish --version "${{ steps.bump.outputs.version }}" --org platform
+          ./scripts/publish_platform_provider.sh \
+            qdrant \
+            "dist/pragmatiks_qdrant_provider-${{ steps.bump.outputs.version }}.tar.gz" \
+            "${{ steps.bump.outputs.version }}"
 
   publish-agno:
     needs: [detect-changes, publish-gcp, publish-kubernetes]
@@ -897,9 +890,6 @@ jobs:
 
       - name: Install commitizen
         run: uv tool install commitizen
-
-      - name: Install pragma CLI
-        run: uv tool install pragmatiks-cli
 
       - name: Configure git
         run: |
@@ -983,10 +973,12 @@ jobs:
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
-          PRAGMA_AUTH_TOKEN: ${{ secrets.PRAGMA_AUTH_TOKEN }}
+          PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
         run: |
-          cd packages/agno
-          pragma providers publish --version "${{ steps.bump.outputs.version }}" --org platform
+          ./scripts/publish_platform_provider.sh \
+            agno \
+            "dist/pragmatiks_agno_provider-${{ steps.bump.outputs.version }}.tar.gz" \
+            "${{ steps.bump.outputs.version }}"
 
       - name: Read runner transport version
         id: runner-transport

--- a/packages/agno/pyproject.toml
+++ b/packages/agno/pyproject.toml
@@ -5,7 +5,7 @@ description = "Agno agent provider for Pragmatiks"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pragmatiks-sdk>=1.2.0",
+    "pragmatiks-sdk>=1.4.0",
     "pragmatiks-gcp-provider>=0.77.0",
     "pragmatiks-kubernetes-provider>=0.171.0",
     "agno[anthropic,openai,postgres,qdrant]>=2.4.0",

--- a/packages/agno/uv.lock
+++ b/packages/agno/uv.lock
@@ -1361,7 +1361,7 @@ wheels = [
 
 [[package]]
 name = "pragmatiks-agno-provider"
-version = "0.118.0"
+version = "0.120.0"
 source = { editable = "." }
 dependencies = [
     { name = "agno", extra = ["anthropic", "openai", "postgres", "qdrant"] },
@@ -1392,7 +1392,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "pragmatiks-gcp-provider", specifier = ">=0.77.0" },
     { name = "pragmatiks-kubernetes-provider", specifier = ">=0.171.0" },
-    { name = "pragmatiks-sdk", specifier = ">=1.2.0" },
+    { name = "pragmatiks-sdk", specifier = ">=1.4.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
 ]
@@ -1441,7 +1441,7 @@ wheels = [
 
 [[package]]
 name = "pragmatiks-sdk"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1449,9 +1449,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/fc/113b34d695938410fdb133b2c8732b0ca227fea2bda8aa5b2052df86cab7/pragmatiks_sdk-1.2.0.tar.gz", hash = "sha256:a1ba9126be12f91d78114cb66936dec3a5004b029a72c1c351dd91e66a00f6de", size = 50175, upload-time = "2026-04-20T11:32:27.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/fd/8581b4ab661431e5ecc41704d9062c2beeb6a817f8f5ff1c92de1a42b7f3/pragmatiks_sdk-1.4.0.tar.gz", hash = "sha256:3c74a311ce4dafd93d388adbf9eccae32384641fac8569a750e7896ec483f9ca", size = 50442, upload-time = "2026-04-24T20:17:27.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/98/132c11f49a13dc6f5bfc085047c3a40daad6e22063b52ee2987c1a75bbb3/pragmatiks_sdk-1.2.0-py3-none-any.whl", hash = "sha256:f6aefeb900e098dd237eb785471b63485168e0f84627c0cad0fdbd9bdd6e4fbd", size = 60030, upload-time = "2026-04-20T11:32:25.954Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/36/185667cc2b892b6dfe0d9f4172d5c0d80d97da6a6a55e5c36d2887f74870/pragmatiks_sdk-1.4.0-py3-none-any.whl", hash = "sha256:4afb72fc9fd46924664b00bc43030f3761b2277b65239e716956a4527f0267af", size = 60364, upload-time = "2026-04-24T20:17:25.842Z" },
 ]
 
 [[package]]

--- a/packages/gcp/pyproject.toml
+++ b/packages/gcp/pyproject.toml
@@ -5,7 +5,7 @@ description = "GCP provider for Pragmatiks"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pragmatiks-sdk>=1.2.0",
+    "pragmatiks-sdk>=1.4.0",
     "google-cloud-container>=2.50.0",
     "google-cloud-logging>=3.10.0",
     "google-cloud-secret-manager>=2.20.0",

--- a/packages/gcp/uv.lock
+++ b/packages/gcp/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "pragmatiks-gcp-provider"
-version = "0.167.1"
+version = "0.174.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },
@@ -644,7 +644,7 @@ requires-dist = [
     { name = "google-cloud-container", specifier = ">=2.50.0" },
     { name = "google-cloud-logging", specifier = ">=3.10.0" },
     { name = "google-cloud-secret-manager", specifier = ">=2.20.0" },
-    { name = "pragmatiks-sdk", specifier = ">=1.2.0" },
+    { name = "pragmatiks-sdk", specifier = ">=1.4.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -658,7 +658,7 @@ dev = [
 
 [[package]]
 name = "pragmatiks-sdk"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -666,9 +666,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/fc/113b34d695938410fdb133b2c8732b0ca227fea2bda8aa5b2052df86cab7/pragmatiks_sdk-1.2.0.tar.gz", hash = "sha256:a1ba9126be12f91d78114cb66936dec3a5004b029a72c1c351dd91e66a00f6de", size = 50175, upload-time = "2026-04-20T11:32:27.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/fd/8581b4ab661431e5ecc41704d9062c2beeb6a817f8f5ff1c92de1a42b7f3/pragmatiks_sdk-1.4.0.tar.gz", hash = "sha256:3c74a311ce4dafd93d388adbf9eccae32384641fac8569a750e7896ec483f9ca", size = 50442, upload-time = "2026-04-24T20:17:27.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/98/132c11f49a13dc6f5bfc085047c3a40daad6e22063b52ee2987c1a75bbb3/pragmatiks_sdk-1.2.0-py3-none-any.whl", hash = "sha256:f6aefeb900e098dd237eb785471b63485168e0f84627c0cad0fdbd9bdd6e4fbd", size = 60030, upload-time = "2026-04-20T11:32:25.954Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/36/185667cc2b892b6dfe0d9f4172d5c0d80d97da6a6a55e5c36d2887f74870/pragmatiks_sdk-1.4.0-py3-none-any.whl", hash = "sha256:4afb72fc9fd46924664b00bc43030f3761b2277b65239e716956a4527f0267af", size = 60364, upload-time = "2026-04-24T20:17:25.842Z" },
 ]
 
 [[package]]

--- a/packages/github/pyproject.toml
+++ b/packages/github/pyproject.toml
@@ -5,7 +5,7 @@ description = "GitHub provider for Pragmatiks"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pragmatiks-sdk>=1.2.0",
+    "pragmatiks-sdk>=1.4.0",
     "httpx>=0.28.0",
     "pynacl>=1.5.0",
 ]

--- a/packages/github/uv.lock
+++ b/packages/github/uv.lock
@@ -230,7 +230,7 @@ wheels = [
 
 [[package]]
 name = "pragmatiks-github-provider"
-version = "0.16.0"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -251,7 +251,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
-    { name = "pragmatiks-sdk", specifier = ">=1.2.0" },
+    { name = "pragmatiks-sdk", specifier = ">=1.4.0" },
     { name = "pynacl", specifier = ">=1.5.0" },
 ]
 
@@ -267,7 +267,7 @@ dev = [
 
 [[package]]
 name = "pragmatiks-sdk"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -275,9 +275,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/fc/113b34d695938410fdb133b2c8732b0ca227fea2bda8aa5b2052df86cab7/pragmatiks_sdk-1.2.0.tar.gz", hash = "sha256:a1ba9126be12f91d78114cb66936dec3a5004b029a72c1c351dd91e66a00f6de", size = 50175, upload-time = "2026-04-20T11:32:27.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/fd/8581b4ab661431e5ecc41704d9062c2beeb6a817f8f5ff1c92de1a42b7f3/pragmatiks_sdk-1.4.0.tar.gz", hash = "sha256:3c74a311ce4dafd93d388adbf9eccae32384641fac8569a750e7896ec483f9ca", size = 50442, upload-time = "2026-04-24T20:17:27.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/98/132c11f49a13dc6f5bfc085047c3a40daad6e22063b52ee2987c1a75bbb3/pragmatiks_sdk-1.2.0-py3-none-any.whl", hash = "sha256:f6aefeb900e098dd237eb785471b63485168e0f84627c0cad0fdbd9bdd6e4fbd", size = 60030, upload-time = "2026-04-20T11:32:25.954Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/36/185667cc2b892b6dfe0d9f4172d5c0d80d97da6a6a55e5c36d2887f74870/pragmatiks_sdk-1.4.0-py3-none-any.whl", hash = "sha256:4afb72fc9fd46924664b00bc43030f3761b2277b65239e716956a4527f0267af", size = 60364, upload-time = "2026-04-24T20:17:25.842Z" },
 ]
 
 [[package]]

--- a/packages/kubernetes/pyproject.toml
+++ b/packages/kubernetes/pyproject.toml
@@ -5,7 +5,7 @@ description = "Generic Kubernetes resources using lightkube"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pragmatiks-sdk>=1.2.0",
+    "pragmatiks-sdk>=1.4.0",
     "pragmatiks-gcp-provider>=0.55.0",
     "lightkube>=0.15.0",
     "google-auth>=2.30.0",

--- a/packages/kubernetes/uv.lock
+++ b/packages/kubernetes/uv.lock
@@ -693,7 +693,7 @@ wheels = [
 
 [[package]]
 name = "pragmatiks-kubernetes-provider"
-version = "0.175.0"
+version = "0.176.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-auth" },
@@ -717,7 +717,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.30.0" },
     { name = "lightkube", specifier = ">=0.15.0" },
     { name = "pragmatiks-gcp-provider", specifier = ">=0.55.0" },
-    { name = "pragmatiks-sdk", specifier = ">=1.2.0" },
+    { name = "pragmatiks-sdk", specifier = ">=1.4.0" },
     { name = "requests", specifier = ">=2.32.0" },
 ]
 
@@ -732,7 +732,7 @@ dev = [
 
 [[package]]
 name = "pragmatiks-sdk"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -740,9 +740,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/fc/113b34d695938410fdb133b2c8732b0ca227fea2bda8aa5b2052df86cab7/pragmatiks_sdk-1.2.0.tar.gz", hash = "sha256:a1ba9126be12f91d78114cb66936dec3a5004b029a72c1c351dd91e66a00f6de", size = 50175, upload-time = "2026-04-20T11:32:27.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/fd/8581b4ab661431e5ecc41704d9062c2beeb6a817f8f5ff1c92de1a42b7f3/pragmatiks_sdk-1.4.0.tar.gz", hash = "sha256:3c74a311ce4dafd93d388adbf9eccae32384641fac8569a750e7896ec483f9ca", size = 50442, upload-time = "2026-04-24T20:17:27.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/98/132c11f49a13dc6f5bfc085047c3a40daad6e22063b52ee2987c1a75bbb3/pragmatiks_sdk-1.2.0-py3-none-any.whl", hash = "sha256:f6aefeb900e098dd237eb785471b63485168e0f84627c0cad0fdbd9bdd6e4fbd", size = 60030, upload-time = "2026-04-20T11:32:25.954Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/36/185667cc2b892b6dfe0d9f4172d5c0d80d97da6a6a55e5c36d2887f74870/pragmatiks_sdk-1.4.0-py3-none-any.whl", hash = "sha256:4afb72fc9fd46924664b00bc43030f3761b2277b65239e716956a4527f0267af", size = 60364, upload-time = "2026-04-24T20:17:25.842Z" },
 ]
 
 [[package]]

--- a/packages/pragma/pyproject.toml
+++ b/packages/pragma/pyproject.toml
@@ -5,7 +5,7 @@ description = "Built-in platform provider for Pragmatiks"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pragmatiks-sdk>=1.2.0",
+    "pragmatiks-sdk>=1.4.0",
     "obstore>=0.5.0",
 ]
 

--- a/packages/pragma/uv.lock
+++ b/packages/pragma/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "pragmatiks-pragma-provider"
-version = "1.3.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "obstore" },
@@ -251,7 +251,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "obstore", specifier = ">=0.5.0" },
-    { name = "pragmatiks-sdk", specifier = ">=1.2.0" },
+    { name = "pragmatiks-sdk", specifier = ">=1.4.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -265,7 +265,7 @@ dev = [
 
 [[package]]
 name = "pragmatiks-sdk"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -273,9 +273,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/fc/113b34d695938410fdb133b2c8732b0ca227fea2bda8aa5b2052df86cab7/pragmatiks_sdk-1.2.0.tar.gz", hash = "sha256:a1ba9126be12f91d78114cb66936dec3a5004b029a72c1c351dd91e66a00f6de", size = 50175, upload-time = "2026-04-20T11:32:27.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/fd/8581b4ab661431e5ecc41704d9062c2beeb6a817f8f5ff1c92de1a42b7f3/pragmatiks_sdk-1.4.0.tar.gz", hash = "sha256:3c74a311ce4dafd93d388adbf9eccae32384641fac8569a750e7896ec483f9ca", size = 50442, upload-time = "2026-04-24T20:17:27.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/98/132c11f49a13dc6f5bfc085047c3a40daad6e22063b52ee2987c1a75bbb3/pragmatiks_sdk-1.2.0-py3-none-any.whl", hash = "sha256:f6aefeb900e098dd237eb785471b63485168e0f84627c0cad0fdbd9bdd6e4fbd", size = 60030, upload-time = "2026-04-20T11:32:25.954Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/36/185667cc2b892b6dfe0d9f4172d5c0d80d97da6a6a55e5c36d2887f74870/pragmatiks_sdk-1.4.0-py3-none-any.whl", hash = "sha256:4afb72fc9fd46924664b00bc43030f3761b2277b65239e716956a4527f0267af", size = 60364, upload-time = "2026-04-24T20:17:25.842Z" },
 ]
 
 [[package]]

--- a/packages/qdrant/pyproject.toml
+++ b/packages/qdrant/pyproject.toml
@@ -5,7 +5,7 @@ description = "Qdrant provider for Pragmatiks"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pragmatiks-sdk>=1.2.0",
+    "pragmatiks-sdk>=1.4.0",
     "pragmatiks-kubernetes-provider>=0.171.0",
     "qdrant-client>=1.12.0",
 ]

--- a/packages/qdrant/uv.lock
+++ b/packages/qdrant/uv.lock
@@ -771,7 +771,7 @@ wheels = [
 
 [[package]]
 name = "pragmatiks-qdrant-provider"
-version = "0.49.0"
+version = "0.56.0"
 source = { editable = "." }
 dependencies = [
     { name = "pragmatiks-kubernetes-provider" },
@@ -791,7 +791,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pragmatiks-kubernetes-provider", specifier = ">=0.171.0" },
-    { name = "pragmatiks-sdk", specifier = ">=1.2.0" },
+    { name = "pragmatiks-sdk", specifier = ">=1.4.0" },
     { name = "qdrant-client", specifier = ">=1.12.0" },
 ]
 
@@ -806,7 +806,7 @@ dev = [
 
 [[package]]
 name = "pragmatiks-sdk"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -814,9 +814,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/fc/113b34d695938410fdb133b2c8732b0ca227fea2bda8aa5b2052df86cab7/pragmatiks_sdk-1.2.0.tar.gz", hash = "sha256:a1ba9126be12f91d78114cb66936dec3a5004b029a72c1c351dd91e66a00f6de", size = 50175, upload-time = "2026-04-20T11:32:27.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/fd/8581b4ab661431e5ecc41704d9062c2beeb6a817f8f5ff1c92de1a42b7f3/pragmatiks_sdk-1.4.0.tar.gz", hash = "sha256:3c74a311ce4dafd93d388adbf9eccae32384641fac8569a750e7896ec483f9ca", size = 50442, upload-time = "2026-04-24T20:17:27.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/98/132c11f49a13dc6f5bfc085047c3a40daad6e22063b52ee2987c1a75bbb3/pragmatiks_sdk-1.2.0-py3-none-any.whl", hash = "sha256:f6aefeb900e098dd237eb785471b63485168e0f84627c0cad0fdbd9bdd6e4fbd", size = 60030, upload-time = "2026-04-20T11:32:25.954Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/36/185667cc2b892b6dfe0d9f4172d5c0d80d97da6a6a55e5c36d2887f74870/pragmatiks_sdk-1.4.0-py3-none-any.whl", hash = "sha256:4afb72fc9fd46924664b00bc43030f3761b2277b65239e716956a4527f0267af", size = 60364, upload-time = "2026-04-24T20:17:25.842Z" },
 ]
 
 [[package]]

--- a/packages/supabase/pyproject.toml
+++ b/packages/supabase/pyproject.toml
@@ -5,7 +5,7 @@ description = "Supabase provider for Pragmatiks"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pragmatiks-sdk>=1.2.0",
+    "pragmatiks-sdk>=1.4.0",
     "httpx>=0.28.0",
 ]
 

--- a/packages/supabase/uv.lock
+++ b/packages/supabase/uv.lock
@@ -185,7 +185,7 @@ wheels = [
 
 [[package]]
 name = "pragmatiks-sdk"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -193,14 +193,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/fc/113b34d695938410fdb133b2c8732b0ca227fea2bda8aa5b2052df86cab7/pragmatiks_sdk-1.2.0.tar.gz", hash = "sha256:a1ba9126be12f91d78114cb66936dec3a5004b029a72c1c351dd91e66a00f6de", size = 50175, upload-time = "2026-04-20T11:32:27.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/fd/8581b4ab661431e5ecc41704d9062c2beeb6a817f8f5ff1c92de1a42b7f3/pragmatiks_sdk-1.4.0.tar.gz", hash = "sha256:3c74a311ce4dafd93d388adbf9eccae32384641fac8569a750e7896ec483f9ca", size = 50442, upload-time = "2026-04-24T20:17:27.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/98/132c11f49a13dc6f5bfc085047c3a40daad6e22063b52ee2987c1a75bbb3/pragmatiks_sdk-1.2.0-py3-none-any.whl", hash = "sha256:f6aefeb900e098dd237eb785471b63485168e0f84627c0cad0fdbd9bdd6e4fbd", size = 60030, upload-time = "2026-04-20T11:32:25.954Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/36/185667cc2b892b6dfe0d9f4172d5c0d80d97da6a6a55e5c36d2887f74870/pragmatiks_sdk-1.4.0-py3-none-any.whl", hash = "sha256:4afb72fc9fd46924664b00bc43030f3761b2277b65239e716956a4527f0267af", size = 60364, upload-time = "2026-04-24T20:17:25.842Z" },
 ]
 
 [[package]]
 name = "pragmatiks-supabase-provider"
-version = "0.18.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -220,7 +220,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
-    { name = "pragmatiks-sdk", specifier = ">=1.2.0" },
+    { name = "pragmatiks-sdk", specifier = ">=1.4.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/packages/vercel/pyproject.toml
+++ b/packages/vercel/pyproject.toml
@@ -5,7 +5,7 @@ description = "Vercel provider for Pragmatiks"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "pragmatiks-sdk>=1.2.0",
+    "pragmatiks-sdk>=1.4.0",
     "httpx>=0.28.0",
 ]
 

--- a/packages/vercel/uv.lock
+++ b/packages/vercel/uv.lock
@@ -185,7 +185,7 @@ wheels = [
 
 [[package]]
 name = "pragmatiks-sdk"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -193,14 +193,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/fc/113b34d695938410fdb133b2c8732b0ca227fea2bda8aa5b2052df86cab7/pragmatiks_sdk-1.2.0.tar.gz", hash = "sha256:a1ba9126be12f91d78114cb66936dec3a5004b029a72c1c351dd91e66a00f6de", size = 50175, upload-time = "2026-04-20T11:32:27.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/fd/8581b4ab661431e5ecc41704d9062c2beeb6a817f8f5ff1c92de1a42b7f3/pragmatiks_sdk-1.4.0.tar.gz", hash = "sha256:3c74a311ce4dafd93d388adbf9eccae32384641fac8569a750e7896ec483f9ca", size = 50442, upload-time = "2026-04-24T20:17:27.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/98/132c11f49a13dc6f5bfc085047c3a40daad6e22063b52ee2987c1a75bbb3/pragmatiks_sdk-1.2.0-py3-none-any.whl", hash = "sha256:f6aefeb900e098dd237eb785471b63485168e0f84627c0cad0fdbd9bdd6e4fbd", size = 60030, upload-time = "2026-04-20T11:32:25.954Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/36/185667cc2b892b6dfe0d9f4172d5c0d80d97da6a6a55e5c36d2887f74870/pragmatiks_sdk-1.4.0-py3-none-any.whl", hash = "sha256:4afb72fc9fd46924664b00bc43030f3761b2277b65239e716956a4527f0267af", size = 60364, upload-time = "2026-04-24T20:17:25.842Z" },
 ]
 
 [[package]]
 name = "pragmatiks-vercel-provider"
-version = "0.16.0"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -220,7 +220,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
-    { name = "pragmatiks-sdk", specifier = ">=1.2.0" },
+    { name = "pragmatiks-sdk", specifier = ">=1.4.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/scripts/publish_platform_provider.sh
+++ b/scripts/publish_platform_provider.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Publish a platform provider tarball to api.pragmatiks.io via the
+# ConsoleMachine-authenticated /console/providers/{name}/publish endpoint.
+#
+# Mints a fresh short-lived Clerk M2M JWT (mt_...) from the long-lived
+# Clerk Machine Secret (ak_...) for each call, then POSTs the tarball as
+# multipart/form-data. No long-lived M2M token is kept in CI.
+#
+# Required env vars:
+#   PRAGMA_CONSOLE_MACHINE_SECRET_KEY  Clerk Machine Secret (ak_...) for
+#                                      the Pragmatiks Console "ci-release"
+#                                      Machine.
+#
+# Optional env vars:
+#   API_BASE_URL                       Default: https://api.pragmatiks.io
+#   MINT_TTL_SECONDS                   Default: 3600 (max 7200)
+#
+# Usage:
+#   publish_platform_provider.sh <provider_short_name> <tarball_path> <version>
+#
+# Example:
+#   publish_platform_provider.sh gcp dist/pragmatiks_gcp_provider-0.173.0.tar.gz 0.173.0
+
+set -euo pipefail
+
+PROVIDER_NAME="${1:?provider_short_name argument is required (e.g. gcp)}"
+TARBALL_PATH="${2:?tarball_path argument is required}"
+VERSION="${3:?version argument is required}"
+
+API_BASE_URL="${API_BASE_URL:-https://api.pragmatiks.io}"
+MINT_TTL_SECONDS="${MINT_TTL_SECONDS:-3600}"
+
+if [ -z "${PRAGMA_CONSOLE_MACHINE_SECRET_KEY:-}" ]; then
+  echo "publish_platform_provider: PRAGMA_CONSOLE_MACHINE_SECRET_KEY is empty or unset" >&2
+  exit 1
+fi
+
+if [ ! -f "${TARBALL_PATH}" ]; then
+  echo "publish_platform_provider: tarball not found at ${TARBALL_PATH}" >&2
+  exit 1
+fi
+
+echo "Minting ConsoleMachine M2M token (ttl=${MINT_TTL_SECONDS}s)..."
+
+MINT_STDERR="$(mktemp)"
+trap 'rm -f "${MINT_STDERR}"' EXIT
+
+if ! TOKEN=$(
+  CONSOLE_CLERK_MACHINE_SECRET_KEY="${PRAGMA_CONSOLE_MACHINE_SECRET_KEY}" \
+  MINT_TTL_SECONDS="${MINT_TTL_SECONDS}" \
+  uv run --isolated --with 'clerk-backend-api>=5.0.2' \
+    python -c '
+import os
+import sys
+
+from clerk_backend_api import Clerk, TokenFormat
+
+ttl = int(os.environ["MINT_TTL_SECONDS"])
+secret = os.environ["CONSOLE_CLERK_MACHINE_SECRET_KEY"]
+
+with Clerk(bearer_auth=secret) as clerk:
+    created = clerk.m2m.create_token(
+        token_format=TokenFormat.JWT,
+        seconds_until_expiration=float(ttl),
+        claims=None,
+    )
+
+token = getattr(created, "token", None)
+if not token:
+    sys.stderr.write(f"mint returned no token: {created!r}\n")
+    sys.exit(1)
+
+sys.stdout.write(token)
+' 2> "${MINT_STDERR}"
+); then
+  echo "publish_platform_provider: failed to mint ConsoleMachine token" >&2
+  cat "${MINT_STDERR}" >&2
+  exit 1
+fi
+
+if [ -z "${TOKEN}" ]; then
+  echo "publish_platform_provider: mint returned an empty token" >&2
+  cat "${MINT_STDERR}" >&2
+  exit 1
+fi
+
+echo "::add-mask::${TOKEN}"
+echo "Minted token (length=${#TOKEN}). Posting ${TARBALL_PATH} to ${API_BASE_URL}..."
+
+RESPONSE_BODY="$(mktemp)"
+trap 'rm -f "${MINT_STDERR}" "${RESPONSE_BODY}"' EXIT
+
+HTTP_CODE=$(
+  curl -sS \
+    -o "${RESPONSE_BODY}" \
+    -w '%{http_code}' \
+    -X POST "${API_BASE_URL}/console/providers/${PROVIDER_NAME}/publish" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -F "version=${VERSION}" \
+    -F "code=@${TARBALL_PATH};type=application/gzip"
+)
+
+if [ "${HTTP_CODE}" -lt 200 ] || [ "${HTTP_CODE}" -ge 300 ]; then
+  echo "publish_platform_provider: API returned HTTP ${HTTP_CODE}" >&2
+  cat "${RESPONSE_BODY}" >&2
+  echo >&2
+  exit 1
+fi
+
+echo "Published platform/${PROVIDER_NAME} v${VERSION} (HTTP ${HTTP_CODE})"
+cat "${RESPONSE_BODY}"
+echo


### PR DESCRIPTION
## Summary

PR 3 of the PRA-369 cascade. Switches the provider publish workflow from the legacy `pragma providers publish --org platform` path (long-lived `PRAGMA_AUTH_TOKEN`) to the new `POST /console/providers/{name}/publish` endpoint authenticated by a freshly minted Clerk ConsoleMachine M2M JWT.

The matching API endpoint (pragma-os PR #150) is live in production at `https://api.pragmatiks.io`.

### Changes
- **`scripts/publish_platform_provider.sh`** — single bash script that mints a short-lived `mt_*` token from `PRAGMA_CONSOLE_MACHINE_SECRET_KEY` (using `clerk-backend-api>=5.0.2` via `uv run --isolated --with`), then POSTs the tarball + `version` form field to `${API_BASE_URL}/console/providers/${provider}/publish`. Mirrors the mint flow used by `pragma-os/.github/actions/mint-console-token` so a leaked CI secret stays short-lived. Defaults `API_BASE_URL=https://api.pragmatiks.io` and `MINT_TTL_SECONDS=3600`.
- **`.github/workflows/publish.yaml`** — replaces the `Publish to pragma store` step in all 8 provider jobs (`gcp`, `kubernetes`, `qdrant`, `agno`, `supabase`, `vercel`, `github`, `pragma`) to call the new script with the matching tarball under `dist/pragmatiks_<name>_provider-${VERSION}.tar.gz`. Drops the now-unused `Install pragma CLI` step from each job.
- **`packages/*/pyproject.toml` + `uv.lock`** — bumps the `pragmatiks-sdk` floor from `>=1.2.0` to `>=1.4.0` and refreshes each provider's lockfile so CI resolves SDK 1.4.0 (already on PyPI).

### Secret name
Used the existing `PRAGMA_CONSOLE_MACHINE_SECRET_KEY` GitHub Actions org secret (already wired into pragma-os's `release-runtime.yaml` via the `mint-console-token` composite action). The task description suggested `CLERK_CONSOLE_MACHINE_SECRET_KEY` but the existing convention in pragma-os is `PRAGMA_CONSOLE_MACHINE_SECRET_KEY`, so I followed that to avoid inventing a new name. Confirm the secret is exposed to the `pragma-providers` repo as well.

### Notes
- All three commits are scoped to shared workflow infrastructure and the SDK floor bump. No provider source code is touched, so the cross-provider commit rule (each provider as an independent PyPI package) still holds at runtime — CI will resolve SDK 1.4.0 from PyPI for every provider.
- The script uses `uv run --isolated --with 'clerk-backend-api>=5.0.2'` rather than copying `pragma-os/scripts/mint_console_token.py`, keeping the publish path inside `pragma-providers` self-contained.

## Test plan
- [ ] Confirm `PRAGMA_CONSOLE_MACHINE_SECRET_KEY` is available to `pragma-providers` (already exists in `pragma-os` org secrets).
- [ ] Trigger `Publish Providers` via `workflow_dispatch` on `main` after merge to verify each provider publishes to PyPI **and** registers with the API console endpoint.
- [ ] Inspect `https://api.pragmatiks.io/providers/platform/<name>/versions/<version>/status` after each job to confirm the API received the build.
- [ ] Verify `Authorization: Bearer mt_*` is masked in the workflow logs (`echo "::add-mask::${TOKEN}"` line in the script).