### PR TITLE
fix(ci): mint opaque M2M token to fix /console publish 401

### DIFF
--- a/scripts/publish_platform_provider.sh
+++ b/scripts/publish_platform_provider.sh
@@ -3,7 +3,7 @@
 # Publish a platform provider tarball to api.pragmatiks.io via the
 # ConsoleMachine-authenticated /console/providers/{name}/publish endpoint.
 #
-# Mints a fresh short-lived Clerk M2M JWT (mt_...) from the long-lived
+# Mints a fresh short-lived Clerk M2M token (mt_...) from the long-lived
 # Clerk Machine Secret (ak_...) for each call, then POSTs the tarball as
 # multipart/form-data. No long-lived M2M token is kept in CI.
 #
@@ -54,14 +54,13 @@ if ! TOKEN=$(
 import os
 import sys
 
-from clerk_backend_api import Clerk, TokenFormat
+from clerk_backend_api import Clerk
 
 ttl = int(os.environ["MINT_TTL_SECONDS"])
 secret = os.environ["CONSOLE_CLERK_MACHINE_SECRET_KEY"]
 
 with Clerk(bearer_auth=secret) as clerk:
     created = clerk.m2m.create_token(
-        token_format=TokenFormat.JWT,
         seconds_until_expiration=float(ttl),
         claims=None,
     )


### PR DESCRIPTION
## Summary

Hot-fix for PRA-369. PR #73 cut over platform provider publish to the new `/console/providers/{name}/publish` endpoint, but all 8 publish jobs returned 401 because the script minted JWT-format M2M tokens that the Clerk SDK misclassifies.

## Root cause

`scripts/publish_platform_provider.sh` called `clerk.m2m.create_token(token_format=TokenFormat.JWT, ...)`. The Clerk SDK's request authenticator (`clerk_backend_api/security/machine.py:get_token_type`) classifies tokens by **prefix**:

- `m2m_*` -> `MACHINE_TOKEN`
- `mt_*`  -> `MACHINE_TOKEN_V2 = "m2m_token"` (the form the API accepts)
- JWT (`eyJ...`) -> falls through to `SESSION_TOKEN`

Because the JWT-format minted token has no `mt_` prefix, the SDK classified it as `SESSION_TOKEN`. The console realm `authenticate_request_async` then routed it through session-token verification, which fails for an M2M JWT. Result: `is_signed_in=False` -> 401 from `/console/providers/{name}/publish`.

The default `create_token(...)` (no `token_format` arg) returns the opaque `mt_*` form, which classifies correctly as `m2m_token` and is verified by Clerk's `/m2m_tokens/verify` endpoint. The API accepts that.

## Change

- Drop `token_format=TokenFormat.JWT` from the `clerk.m2m.create_token(...)` call.
- Drop the now-unused `TokenFormat` import.
- Update the header comment: "Clerk M2M JWT (mt_...)" -> "Clerk M2M token (mt_...)".

Diff is 5 lines.

## Test plan

- [x] `bash -n scripts/publish_platform_provider.sh` (syntax check)
- [ ] Merge to main; the next platform provider publish run on `update-sdk`/release should succeed against `/console/providers/{name}/publish` (cannot smoke-test locally without `PRAGMA_CONSOLE_MACHINE_SECRET_KEY`).