### PR TITLE
fix(ci): forward provider metadata to /console publish (PRA-369)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -166,7 +166,8 @@ jobs:
           ./scripts/publish_platform_provider.sh \
             gcp \
             "dist/pragmatiks_gcp_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}"
+            "${{ steps.bump.outputs.version }}" \
+            packages/gcp/pyproject.toml
 
   publish-supabase:
     needs: [detect-changes]
@@ -267,7 +268,8 @@ jobs:
           ./scripts/publish_platform_provider.sh \
             supabase \
             "dist/pragmatiks_supabase_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}"
+            "${{ steps.bump.outputs.version }}" \
+            packages/supabase/pyproject.toml
 
   publish-vercel:
     needs: [detect-changes]
@@ -368,7 +370,8 @@ jobs:
           ./scripts/publish_platform_provider.sh \
             vercel \
             "dist/pragmatiks_vercel_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}"
+            "${{ steps.bump.outputs.version }}" \
+            packages/vercel/pyproject.toml
 
   publish-github:
     needs: [detect-changes]
@@ -469,7 +472,8 @@ jobs:
           ./scripts/publish_platform_provider.sh \
             github \
             "dist/pragmatiks_github_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}"
+            "${{ steps.bump.outputs.version }}" \
+            packages/github/pyproject.toml
 
   publish-pragma:
     needs: [detect-changes]
@@ -570,7 +574,8 @@ jobs:
           ./scripts/publish_platform_provider.sh \
             pragma \
             "dist/pragmatiks_pragma_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}"
+            "${{ steps.bump.outputs.version }}" \
+            packages/pragma/pyproject.toml
 
   publish-kubernetes:
     needs: [detect-changes, publish-gcp]
@@ -703,7 +708,8 @@ jobs:
           ./scripts/publish_platform_provider.sh \
             kubernetes \
             "dist/pragmatiks_kubernetes_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}"
+            "${{ steps.bump.outputs.version }}" \
+            packages/kubernetes/pyproject.toml
 
   publish-qdrant:
     needs: [detect-changes, publish-kubernetes]
@@ -835,7 +841,8 @@ jobs:
           ./scripts/publish_platform_provider.sh \
             qdrant \
             "dist/pragmatiks_qdrant_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}"
+            "${{ steps.bump.outputs.version }}" \
+            packages/qdrant/pyproject.toml
 
   publish-agno:
     needs: [detect-changes, publish-gcp, publish-kubernetes]
@@ -978,7 +985,8 @@ jobs:
           ./scripts/publish_platform_provider.sh \
             agno \
             "dist/pragmatiks_agno_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}"
+            "${{ steps.bump.outputs.version }}" \
+            packages/agno/pyproject.toml
 
       - name: Read runner transport version
         id: runner-transport

--- a/scripts/publish_platform_provider.sh
+++ b/scripts/publish_platform_provider.sh
@@ -17,16 +17,25 @@
 #   MINT_TTL_SECONDS                   Default: 3600 (max 7200)
 #
 # Usage:
-#   publish_platform_provider.sh <provider_short_name> <tarball_path> <version>
+#   publish_platform_provider.sh <provider_short_name> <tarball_path> <version> <pyproject_path>
+#
+# The pyproject_path points at the provider's pyproject.toml. Provider
+# metadata (display_name, description, icon_url, tags) is read from the
+# [tool.pragma] table and forwarded to the API as form fields.
 #
 # Example:
-#   publish_platform_provider.sh gcp dist/pragmatiks_gcp_provider-0.173.0.tar.gz 0.173.0
+#   publish_platform_provider.sh \
+#     gcp \
+#     dist/pragmatiks_gcp_provider-0.173.0.tar.gz \
+#     0.173.0 \
+#     packages/gcp/pyproject.toml
 
 set -euo pipefail
 
 PROVIDER_NAME="${1:?provider_short_name argument is required (e.g. gcp)}"
 TARBALL_PATH="${2:?tarball_path argument is required}"
 VERSION="${3:?version argument is required}"
+PYPROJECT_PATH="${4:?pyproject_path argument is required (e.g. packages/gcp/pyproject.toml)}"
 
 API_BASE_URL="${API_BASE_URL:-https://api.pragmatiks.io}"
 MINT_TTL_SECONDS="${MINT_TTL_SECONDS:-3600}"
@@ -40,6 +49,77 @@ if [ ! -f "${TARBALL_PATH}" ]; then
   echo "publish_platform_provider: tarball not found at ${TARBALL_PATH}" >&2
   exit 1
 fi
+
+if [ ! -f "${PYPROJECT_PATH}" ]; then
+  echo "publish_platform_provider: pyproject not found at ${PYPROJECT_PATH}" >&2
+  exit 1
+fi
+
+echo "Reading provider metadata from ${PYPROJECT_PATH}..."
+
+if ! METADATA=$(
+  PYPROJECT_PATH="${PYPROJECT_PATH}" \
+  uv run --isolated python -c '
+import json
+import os
+import sys
+import tomllib
+
+path = os.environ["PYPROJECT_PATH"]
+with open(path, "rb") as f:
+    data = tomllib.load(f)
+
+pragma = data.get("tool", {}).get("pragma", {})
+
+display_name = pragma.get("display_name")
+description = pragma.get("description")
+if not display_name or not description:
+    sys.stderr.write(
+        f"{path}: [tool.pragma] must define both display_name and description\n"
+    )
+    sys.exit(1)
+
+icon_url = pragma.get("icon_url") or ""
+tags = pragma.get("tags") or []
+if not isinstance(tags, list):
+    sys.stderr.write(f"{path}: [tool.pragma].tags must be an array\n")
+    sys.exit(1)
+tags_json = json.dumps(tags) if tags else ""
+
+# Emit shell-evaluable lines: KEY=<base64-encoded value>. Base64 keeps
+# arbitrary characters (quotes, newlines, shell metachars) safe across
+# the bash boundary.
+import base64
+
+def emit(key: str, value: str) -> None:
+    encoded = base64.b64encode(value.encode("utf-8")).decode("ascii")
+    sys.stdout.write(f"{key}={encoded}\n")
+
+emit("DISPLAY_NAME", display_name)
+emit("DESCRIPTION", description)
+emit("ICON_URL", icon_url)
+emit("TAGS_JSON", tags_json)
+'
+); then
+  echo "publish_platform_provider: failed to read metadata from ${PYPROJECT_PATH}" >&2
+  exit 1
+fi
+
+decode_meta() {
+  local key="$1"
+  local line
+  line=$(printf '%s\n' "${METADATA}" | grep "^${key}=" || true)
+  if [ -z "${line}" ]; then
+    echo ""
+    return
+  fi
+  printf '%s' "${line#${key}=}" | base64 --decode
+}
+
+DISPLAY_NAME=$(decode_meta DISPLAY_NAME)
+DESCRIPTION=$(decode_meta DESCRIPTION)
+ICON_URL=$(decode_meta ICON_URL)
+TAGS_JSON=$(decode_meta TAGS_JSON)
 
 echo "Minting ConsoleMachine M2M token (ttl=${MINT_TTL_SECONDS}s)..."
 
@@ -90,14 +170,30 @@ echo "Minted token (length=${#TOKEN}). Posting ${TARBALL_PATH} to ${API_BASE_URL
 RESPONSE_BODY="$(mktemp)"
 trap 'rm -f "${MINT_STDERR}" "${RESPONSE_BODY}"' EXIT
 
+CURL_FORM_ARGS=(
+  -F "version=${VERSION}"
+  -F "display_name=${DISPLAY_NAME}"
+  -F "description=${DESCRIPTION}"
+)
+
+# Optional fields are omitted entirely when empty so the API form parser
+# treats them as absent rather than empty strings.
+if [ -n "${ICON_URL}" ]; then
+  CURL_FORM_ARGS+=(-F "icon_url=${ICON_URL}")
+fi
+if [ -n "${TAGS_JSON}" ]; then
+  CURL_FORM_ARGS+=(-F "tags=${TAGS_JSON}")
+fi
+
+CURL_FORM_ARGS+=(-F "code=@${TARBALL_PATH};type=application/gzip")
+
 HTTP_CODE=$(
   curl -sS \
     -o "${RESPONSE_BODY}" \
     -w '%{http_code}' \
     -X POST "${API_BASE_URL}/console/providers/${PROVIDER_NAME}/publish" \
     -H "Authorization: Bearer ${TOKEN}" \
-    -F "version=${VERSION}" \
-    -F "code=@${TARBALL_PATH};type=application/gzip"
+    "${CURL_FORM_ARGS[@]}"
 )
 
 if [ "${HTTP_CODE}" -lt 200 ] || [ "${HTTP_CODE}" -ge 300 ]; then


### PR DESCRIPTION
## Summary

After the catalog wipe (PRA-369 cutover to `/console/providers/{name}/publish`), every provider publish is now a first publish — the API enforces `display_name` and `description` and returns 422 without them. The mint half of the script is fine, the form half is missing all the metadata fields.

This change extends `scripts/publish_platform_provider.sh` to:

- Take a fourth argument `<pyproject_path>` pointing at the provider's `pyproject.toml`.
- Read `display_name`, `description`, `icon_url`, and `tags` from `[tool.pragma]` using `tomllib` (Python 3.13 stdlib, no extra `--with`).
- Fail loudly if `display_name` or `description` is missing (no fallbacks).
- Forward all four fields as `multipart/form-data` to the API. Optional fields (`icon_url`, `tags`) are omitted entirely when empty so the form parser treats them as absent rather than as empty strings. `tags` is JSON-encoded since the API parses it via `_parse_tags_form`.

The shell <-> Python boundary uses base64 round-trip so quotes, slashes, or other shell metacharacters in metadata values (e.g. the GCP icon URL) cannot break parsing.

All 8 callers in `.github/workflows/publish.yaml` (gcp, kubernetes, qdrant, agno, supabase, vercel, github, pragma) are updated to pass `packages/<name>/pyproject.toml` as the new fourth argument.

## Test plan

- [x] `bash -n scripts/publish_platform_provider.sh` passes.
- [x] Local round-trip test with `packages/gcp/pyproject.toml` decodes display_name / description / icon_url / tags correctly.
- [x] Validation test: a synthetic pyproject without `display_name` exits 1 with a clear error.
- [ ] Smoke test: next publish workflow run on main publishes successfully (HTTP 2xx) instead of 422.