### PR TITLE
feat(ci): add allow_no_commit dispatch input for catalog repopulation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      allow_no_commit:
+        description: "Force commitizen to bump even with no eligible commits (use after a catalog wipe)"
+        type: boolean
+        required: false
+        default: false
 
 # Provider dependency DAG:
 #   gcp, supabase, vercel, github, pragma  (no internal deps — run in parallel)
@@ -112,9 +118,11 @@ jobs:
 
       - name: Bump and build
         id: bump
+        env:
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
         run: |
           cd packages/gcp
-          if cz bump --yes --changelog 2>&1 | tee bump_output.txt; then
+          if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
             VERSION=$(cz version --project)
             echo "Bumped gcp to v$VERSION"
             echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -214,9 +222,11 @@ jobs:
 
       - name: Bump and build
         id: bump
+        env:
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
         run: |
           cd packages/supabase
-          if cz bump --yes --changelog 2>&1 | tee bump_output.txt; then
+          if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
             VERSION=$(cz version --project)
             echo "Bumped supabase to v$VERSION"
             echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -316,9 +326,11 @@ jobs:
 
       - name: Bump and build
         id: bump
+        env:
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
         run: |
           cd packages/vercel
-          if cz bump --yes --changelog 2>&1 | tee bump_output.txt; then
+          if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
             VERSION=$(cz version --project)
             echo "Bumped vercel to v$VERSION"
             echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -418,9 +430,11 @@ jobs:
 
       - name: Bump and build
         id: bump
+        env:
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
         run: |
           cd packages/github
-          if cz bump --yes --changelog 2>&1 | tee bump_output.txt; then
+          if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
             VERSION=$(cz version --project)
             echo "Bumped github to v$VERSION"
             echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -520,9 +534,11 @@ jobs:
 
       - name: Bump and build
         id: bump
+        env:
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
         run: |
           cd packages/pragma
-          if cz bump --yes --changelog 2>&1 | tee bump_output.txt; then
+          if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
             VERSION=$(cz version --project)
             echo "Bumped pragma to v$VERSION"
             echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -654,9 +670,11 @@ jobs:
 
       - name: Bump and build
         id: bump
+        env:
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
         run: |
           cd packages/kubernetes
-          if cz bump --yes --changelog 2>&1 | tee bump_output.txt; then
+          if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
             VERSION=$(cz version --project)
             echo "Bumped kubernetes to v$VERSION"
             echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -787,9 +805,11 @@ jobs:
 
       - name: Bump and build
         id: bump
+        env:
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
         run: |
           cd packages/qdrant
-          if cz bump --yes --changelog 2>&1 | tee bump_output.txt; then
+          if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
             VERSION=$(cz version --project)
             echo "Bumped qdrant to v$VERSION"
             echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -931,9 +951,11 @@ jobs:
 
       - name: Bump and build
         id: bump
+        env:
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
         run: |
           cd packages/agno
-          if cz bump --yes --changelog 2>&1 | tee bump_output.txt; then
+          if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
             VERSION=$(cz version --project)
             echo "Bumped agno to v$VERSION"
             echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Adds an `allow_no_commit` boolean input to the `workflow_dispatch` trigger of `publish.yaml`.
- Wires `--allow-no-commit` into all 8 provider `cz bump` steps (gcp, supabase, vercel, github, pragma, kubernetes, qdrant, agno) when the input is set.
- Push-triggered runs are unaffected — the env expression evaluates to an empty string, so `cz bump --yes --changelog` runs exactly as before.

## Why

After the SurrealDB wipe for PRA-369, the platform catalog needs a fresh publish for every provider, but there are no eligible Conventional Commits since the last tag. Commitizen's documented [`--allow-no-commit`](https://commitizen-tools.github.io/commitizen/commands/bump/) flag forces a bump in that case (defaults to PATCH). This input lets us trigger a manual republish via the Actions UI without inventing dummy `feat:`/`fix:` commits in each package.

## Test plan

- [ ] Verify `actionlint` passes locally if available (not installed in this env; `python -c "yaml.safe_load(...)"` succeeds).
- [ ] Trigger `Publish Providers` manually via the Actions UI **without** the box checked — confirm normal "no bump needed" short-circuit still applies for providers with no eligible commits.
- [ ] Trigger manually **with** `allow_no_commit` checked — confirm every provider produces a PATCH bump, builds, publishes to PyPI, and republishes to the pragma store via `publish_platform_provider.sh`.
- [ ] Confirm the agno-runner image build still triggers off the agno PyPI publish wait step.