### PR TITLE
feat(agno): add thinking-mode support to models/anthropic

### DIFF
--- a/packages/agno/src/agno_provider/resources/models/anthropic.py
+++ b/packages/agno/src/agno_provider/resources/models/anthropic.py
@@ -14,6 +14,22 @@ from agno_provider.resources.models.base import Model, ModelConfig, ModelOutputs
 
 
 ThinkingMode = Literal["off", "extended", "adaptive"]
+EffortLevel = Literal["low", "medium", "high", "xhigh", "max"]
+
+
+INCOMPATIBLE_MODE_BY_PREFIX: dict[str, ThinkingMode] = {
+    "claude-opus-4-7": "extended",
+    "claude-haiku-4-5": "adaptive",
+}
+"""Maps a model id prefix to the thinking_mode it does NOT support.
+
+Per the Anthropic compatibility matrix, ``claude-opus-4-7*`` is adaptive-only
+and ``claude-haiku-4-5*`` is extended-only. Older families (sonnet-4-5,
+opus-4-5, sonnet-3-7) accept either mode and are not listed.
+
+See https://platform.claude.com/docs/en/build-with-claude/extended-thinking
+and https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking.
+"""
 
 
 def _build_thinking_param(
@@ -43,6 +59,77 @@ def _build_thinking_param(
     return {"type": "enabled", "budget_tokens": thinking_budget_tokens}
 
 
+def _build_output_config_param(
+    thinking_mode: ThinkingMode,
+    effort: EffortLevel | None,
+) -> dict[str, Any] | None:
+    """Translate ``effort`` into agno's ``output_config`` dict.
+
+    Anthropic's adaptive-thinking mode pairs with a top-level ``output_config``
+    object that carries the ``effort`` knob (``low`` / ``medium`` / ``high`` /
+    ``xhigh`` / ``max``). Agno's ``Claude`` class plumbs ``output_config``
+    straight through to the Anthropic API.
+
+    Args:
+        thinking_mode: One of "off", "extended", or "adaptive".
+        effort: Effort level for adaptive thinking. Only valid when
+            ``thinking_mode`` is "adaptive".
+
+    Returns:
+        Dict to pass to ``Claude(output_config=...)``, or ``None`` when no
+        effort is configured.
+    """
+    if thinking_mode != "adaptive" or effort is None:
+        return None
+
+    return {"effort": effort}
+
+
+def _validate_thinking_fields(
+    thinking_mode: ThinkingMode,
+    thinking_budget_tokens: int | None,
+    effort: EffortLevel | None,
+) -> None:
+    """Enforce per-mode constraints on thinking-related fields.
+
+    ``"off"`` rejects both ``thinking_budget_tokens`` and ``effort``.
+    ``"extended"`` requires a positive ``thinking_budget_tokens`` and rejects
+    ``effort``. ``"adaptive"`` rejects ``thinking_budget_tokens`` and accepts
+    optional ``effort``.
+
+    Args:
+        thinking_mode: One of "off", "extended", or "adaptive".
+        thinking_budget_tokens: Token budget for extended thinking.
+        effort: Effort level for adaptive thinking.
+
+    Raises:
+        ValueError: If any field is set in a mode that does not accept it,
+            or if ``thinking_budget_tokens`` is missing/non-positive in
+            ``"extended"`` mode.
+    """
+    if thinking_mode == "off":
+        if thinking_budget_tokens is not None:
+            msg = "thinking_budget_tokens must be None when thinking_mode is 'off'"
+            raise ValueError(msg)
+        if effort is not None:
+            msg = "effort must be None when thinking_mode is 'off'"
+            raise ValueError(msg)
+        return
+
+    if thinking_mode == "extended":
+        if thinking_budget_tokens is None or thinking_budget_tokens <= 0:
+            msg = "thinking_budget_tokens must be a positive integer when thinking_mode is 'extended'"
+            raise ValueError(msg)
+        if effort is not None:
+            msg = "effort must be None when thinking_mode is 'extended' (effort is only valid for 'adaptive')"
+            raise ValueError(msg)
+        return
+
+    if thinking_budget_tokens is not None:
+        msg = "thinking_budget_tokens must be None when thinking_mode is 'adaptive' (adaptive picks its own budget)"
+        raise ValueError(msg)
+
+
 class AnthropicModelSpec(AgnoSpec):
     """Specification for an Anthropic Claude model.
 
@@ -65,6 +152,10 @@ class AnthropicModelSpec(AgnoSpec):
         thinking_budget_tokens: Token budget for extended thinking. Required
             (positive int) when ``thinking_mode == "extended"``; must be
             ``None`` for the other modes.
+        effort: Effort knob for ``"adaptive"`` thinking. Only valid when
+            ``thinking_mode == "adaptive"``; must be ``None`` for the other
+            modes. Defaults to ``None``, which lets Anthropic pick its
+            default effort level (currently ``"high"``).
     """
 
     type: Literal["anthropic"] = "anthropic"
@@ -77,6 +168,17 @@ class AnthropicModelSpec(AgnoSpec):
     stop_sequences: list[str] | None = None
     thinking_mode: ThinkingMode = "off"
     thinking_budget_tokens: int | None = None
+    effort: EffortLevel | None = None
+
+    @model_validator(mode="after")
+    def validate_thinking_fields(self) -> AnthropicModelSpec:
+        """Enforce per-mode constraints on thinking-related fields.
+
+        Returns:
+            Self after validation.
+        """
+        _validate_thinking_fields(self.thinking_mode, self.thinking_budget_tokens, self.effort)
+        return self
 
 
 class AnthropicModelConfig(ModelConfig):
@@ -94,12 +196,18 @@ class AnthropicModelConfig(ModelConfig):
         thinking_mode: Extended-thinking mode. Defaults to ``"off"``. Set to
             ``"extended"`` to enable Anthropic extended thinking with a fixed
             ``thinking_budget_tokens`` budget, or ``"adaptive"`` to let the
-            model pick its own budget per turn. Note that some Claude model
-            ids (e.g. Claude 3 / 3.5 Haiku families) do not support thinking;
-            agno will reject the combination at runtime.
+            model pick its own budget per turn. Per-model compatibility is
+            checked in ``on_create`` against Anthropic's documented matrix
+            (e.g. ``claude-opus-4-7`` is adaptive-only; ``claude-haiku-4-5``
+            is extended-only).
         thinking_budget_tokens: Token budget when ``thinking_mode`` is
             ``"extended"``. Required (positive integer) in that mode and must
             be omitted for ``"off"`` and ``"adaptive"``.
+        effort: Effort knob when ``thinking_mode`` is ``"adaptive"``. One of
+            ``"low"``, ``"medium"``, ``"high"``, ``"xhigh"``, ``"max"``. Must
+            be omitted for ``"off"`` and ``"extended"``. When omitted in
+            adaptive mode, Anthropic uses its default effort (currently
+            ``"high"``).
     """
 
     api_key: SensitiveField[str]
@@ -110,30 +218,16 @@ class AnthropicModelConfig(ModelConfig):
     stop_sequences: Field[list[str]] | None = None
     thinking_mode: Field[ThinkingMode] = "off"
     thinking_budget_tokens: Field[int] | None = None
+    effort: Field[EffortLevel] | None = None
 
     @model_validator(mode="after")
-    def validate_thinking_budget(self) -> AnthropicModelConfig:
-        """Enforce that ``thinking_budget_tokens`` matches ``thinking_mode``.
-
-        ``"extended"`` requires a positive ``thinking_budget_tokens``;
-        ``"off"`` and ``"adaptive"`` reject any budget so the catalog cannot
-        accidentally silently drop a configured budget when switching modes.
+    def validate_thinking_fields(self) -> AnthropicModelConfig:
+        """Enforce per-mode constraints on thinking-related fields.
 
         Returns:
             Self after validation.
-
-        Raises:
-            ValueError: If the budget is missing/non-positive for
-                ``"extended"``, or set for ``"off"`` / ``"adaptive"``.
         """
-        if self.thinking_mode == "extended":
-            if self.thinking_budget_tokens is None or self.thinking_budget_tokens <= 0:
-                msg = "thinking_budget_tokens must be a positive integer when thinking_mode is 'extended'"
-                raise ValueError(msg)
-        elif self.thinking_budget_tokens is not None:
-            msg = f"thinking_budget_tokens must be None when thinking_mode is {self.thinking_mode!r}"
-            raise ValueError(msg)
-
+        _validate_thinking_fields(self.thinking_mode, self.thinking_budget_tokens, self.effort)
         return self
 
 
@@ -173,9 +267,11 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
         ``thinking_mode`` and ``thinking_budget_tokens`` are translated into
         the ``thinking`` dict shape that ``agno.models.anthropic.Claude``
         expects (``{"type": "enabled", "budget_tokens": N}`` for extended
-        thinking, ``{"type": "adaptive"}`` for adaptive). The high-level
-        fields are not forwarded as kwargs because Claude does not accept
-        them directly.
+        thinking, ``{"type": "adaptive"}`` for adaptive). When ``effort`` is
+        set (adaptive mode only), it is forwarded as
+        ``output_config={"effort": <level>}`` which agno passes through to
+        the Anthropic API. The high-level fields are not forwarded as
+        kwargs because Claude does not accept them directly.
 
         Args:
             spec: The model specification.
@@ -184,13 +280,17 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
             Configured Claude instance ready for use.
         """
         kwargs = spec.model_dump(
-            exclude={"type", "thinking_mode", "thinking_budget_tokens"},
+            exclude={"type", "thinking_mode", "thinking_budget_tokens", "effort"},
             exclude_none=True,
         )
 
         thinking = _build_thinking_param(spec.thinking_mode, spec.thinking_budget_tokens)
         if thinking is not None:
             kwargs["thinking"] = thinking
+
+        output_config = _build_output_config_param(spec.thinking_mode, spec.effort)
+        if output_config is not None:
+            kwargs["output_config"] = output_config
 
         return Claude(**kwargs)
 
@@ -213,6 +313,7 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
             stop_sequences=self.config.stop_sequences,
             thinking_mode=self.config.thinking_mode,
             thinking_budget_tokens=self.config.thinking_budget_tokens,
+            effort=self.config.effort,
         )
 
     def _build_outputs(self) -> AnthropicModelOutputs:
@@ -224,19 +325,51 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
         return AnthropicModelOutputs(spec=self._build_spec())
 
     async def on_create(self) -> AnthropicModelOutputs:
-        """Validate credentials against Anthropic and return outputs with spec.
+        """Validate credentials and model/mode compatibility, then return outputs.
 
         Performs a lightweight ``client.models.retrieve`` round-trip so an
         invalid API key or nonexistent model id fails the resource at
-        create time rather than on first agent invocation. Any error from
-        the Anthropic SDK propagates so the runtime marks the resource
-        FAILED.
+        create time rather than on first agent invocation. Then checks the
+        configured ``thinking_mode`` against Anthropic's per-model matrix so
+        bad combinations (e.g. ``claude-opus-4-7`` with extended thinking)
+        fail the resource here rather than at runner-pod startup. Any error
+        propagates so the runtime marks the resource FAILED.
 
         Returns:
             AnthropicModelOutputs with spec.
         """
         await self._validate_credentials()
+        self._validate_model_thinking_compatibility()
         return self._build_outputs()
+
+    def _validate_model_thinking_compatibility(self) -> None:
+        """Reject model/thinking-mode combinations Anthropic does not accept.
+
+        Some Claude families only support one thinking mode — for example,
+        ``claude-opus-4-7`` is adaptive-only and ``claude-haiku-4-5`` is
+        extended-only. Older families (sonnet-4-5, opus-4-5, sonnet-3-7)
+        accept manual thinking and are not flagged here. ``"off"`` always
+        passes since both modes can be disabled.
+
+        See https://platform.claude.com/docs/en/build-with-claude/extended-thinking
+        and https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+        for the authoritative compatibility matrix.
+
+        Raises:
+            ValueError: If the model id and thinking_mode combination is
+                not supported by Anthropic.
+        """
+        if self.config.thinking_mode == "off":
+            return
+
+        for prefix, incompatible_mode in INCOMPATIBLE_MODE_BY_PREFIX.items():
+            if self.config.id.startswith(prefix) and self.config.thinking_mode == incompatible_mode:
+                msg = (
+                    f"Model {self.config.id!r} does not support thinking_mode={incompatible_mode!r}. "
+                    f"See https://platform.claude.com/docs/en/build-with-claude/extended-thinking "
+                    f"for the per-model compatibility matrix."
+                )
+                raise ValueError(msg)
 
     async def _validate_credentials(self) -> None:
         """Round-trip to Anthropic to verify the API key and model id.

--- a/packages/agno/src/agno_provider/resources/models/anthropic.py
+++ b/packages/agno/src/agno_provider/resources/models/anthropic.py
@@ -32,6 +32,21 @@ and https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking.
 """
 
 
+NO_THINKING_MODEL_PREFIXES: frozenset[str] = frozenset({
+    "claude-3-haiku-",
+    "claude-3-5-haiku-",
+})
+"""Model id prefixes that do not support extended thinking at all.
+
+Mirrors the entries in ``agno.models.anthropic.Claude.NON_THINKING_MODELS``
+(``claude-3-haiku-20240307``, ``claude-3-5-haiku-20241022``,
+``claude-3-5-haiku-latest``). Any non-``"off"`` thinking_mode on a model
+matching one of these prefixes is rejected by ``Claude.__post_init__``;
+catching it here keeps the failure at apply time rather than runner-pod
+startup.
+"""
+
+
 def _build_thinking_param(
     thinking_mode: ThinkingMode,
     thinking_budget_tokens: int | None,
@@ -101,7 +116,9 @@ def _validate_thinking_fields(
     Numeric checks against ``thinking_budget_tokens`` are skipped when
     the value is a ``FieldReference`` (still unresolved). Reference
     values get re-validated on the resolved Spec where they are
-    guaranteed to be concrete integers.
+    guaranteed to be concrete integers. The whole helper is skipped
+    when ``thinking_mode`` itself is a ``FieldReference``; mode-aware
+    validation re-runs against the resolved Spec.
 
     Args:
         thinking_mode: One of "off", "extended", or "adaptive".
@@ -113,6 +130,9 @@ def _validate_thinking_fields(
             it, or if ``thinking_budget_tokens`` is missing or below
             1024 (when concrete) in ``"extended"`` mode.
     """
+    if not isinstance(thinking_mode, str):
+        return
+
     if thinking_mode == "off":
         if thinking_budget_tokens is not None:
             msg = "thinking_budget_tokens must be None when thinking_mode is 'off'"
@@ -395,9 +415,16 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
 
         Some Claude families only support one thinking mode — for example,
         ``claude-opus-4-7`` is adaptive-only and ``claude-haiku-4-5`` is
-        extended-only. Older families (sonnet-4-5, opus-4-5, sonnet-3-7)
-        accept manual thinking and are not flagged here. ``"off"`` always
-        passes since both modes can be disabled.
+        extended-only. Legacy haiku families (``claude-3-haiku-*``,
+        ``claude-3-5-haiku-*``) do not support extended thinking at all
+        and reject any non-``"off"`` mode. Older sonnet/opus families
+        (sonnet-4-5, opus-4-5, sonnet-3-7) accept manual thinking and
+        are not flagged here. ``"off"`` always passes since both modes
+        can be disabled.
+
+        Skipped when ``self.config.id`` or ``self.config.thinking_mode``
+        is a ``FieldReference``; the resolved Spec re-runs equivalent
+        per-mode validation before reaching the runner.
 
         See https://platform.claude.com/docs/en/build-with-claude/extended-thinking
         and https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
@@ -407,8 +434,21 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
             ValueError: If the model id and thinking_mode combination is
                 not supported by Anthropic.
         """
+        if not isinstance(self.config.id, str) or not isinstance(self.config.thinking_mode, str):
+            return
+
         if self.config.thinking_mode == "off":
             return
+
+        for prefix in NO_THINKING_MODEL_PREFIXES:
+            if self.config.id.startswith(prefix):
+                msg = (
+                    f"Model {self.config.id!r} does not support extended thinking; "
+                    f"thinking_mode must be 'off'. "
+                    f"See https://platform.claude.com/docs/en/build-with-claude/extended-thinking "
+                    f"for the per-model compatibility matrix."
+                )
+                raise ValueError(msg)
 
         for prefix, incompatible_mode in INCOMPATIBLE_MODE_BY_PREFIX.items():
             if self.config.id.startswith(prefix) and self.config.thinking_mode == incompatible_mode:

--- a/packages/agno/src/agno_provider/resources/models/anthropic.py
+++ b/packages/agno/src/agno_provider/resources/models/anthropic.py
@@ -93,9 +93,15 @@ def _validate_thinking_fields(
     """Enforce per-mode constraints on thinking-related fields.
 
     ``"off"`` rejects both ``thinking_budget_tokens`` and ``effort``.
-    ``"extended"`` requires ``thinking_budget_tokens >= 1024`` (Anthropic API
-    minimum) and rejects ``effort``. ``"adaptive"`` rejects
+    ``"extended"`` requires ``thinking_budget_tokens`` to be set, and when
+    it is a concrete integer it must be ``>= 1024`` (Anthropic API
+    minimum); ``effort`` is rejected. ``"adaptive"`` rejects
     ``thinking_budget_tokens`` and accepts optional ``effort``.
+
+    Numeric checks against ``thinking_budget_tokens`` are skipped when
+    the value is a ``FieldReference`` (still unresolved). Reference
+    values get re-validated on the resolved Spec where they are
+    guaranteed to be concrete integers.
 
     Args:
         thinking_mode: One of "off", "extended", or "adaptive".
@@ -103,9 +109,9 @@ def _validate_thinking_fields(
         effort: Effort level for adaptive thinking.
 
     Raises:
-        ValueError: If any field is set in a mode that does not accept it,
-            or if ``thinking_budget_tokens`` is missing/below 1024 in
-            ``"extended"`` mode.
+        ValueError: If any field is set in a mode that does not accept
+            it, or if ``thinking_budget_tokens`` is missing or below
+            1024 (when concrete) in ``"extended"`` mode.
     """
     if thinking_mode == "off":
         if thinking_budget_tokens is not None:
@@ -117,7 +123,10 @@ def _validate_thinking_fields(
         return
 
     if thinking_mode == "extended":
-        if thinking_budget_tokens is None or thinking_budget_tokens < 1024:
+        if thinking_budget_tokens is None:
+            msg = "extended thinking requires thinking_budget_tokens >= 1024 (Anthropic API minimum)"
+            raise ValueError(msg)
+        if isinstance(thinking_budget_tokens, int) and thinking_budget_tokens < 1024:
             msg = "extended thinking requires thinking_budget_tokens >= 1024 (Anthropic API minimum)"
             raise ValueError(msg)
         if effort is not None:

--- a/packages/agno/src/agno_provider/resources/models/anthropic.py
+++ b/packages/agno/src/agno_provider/resources/models/anthropic.py
@@ -2,14 +2,45 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 import anthropic
 from agno.models.anthropic import Claude
 from pragma_sdk import Field, SensitiveField
+from pydantic import model_validator
 
 from agno_provider.resources.base import AgnoSpec
 from agno_provider.resources.models.base import Model, ModelConfig, ModelOutputs
+
+
+ThinkingMode = Literal["off", "extended", "adaptive"]
+
+
+def _build_thinking_param(
+    thinking_mode: ThinkingMode,
+    thinking_budget_tokens: int | None,
+) -> dict[str, Any] | None:
+    """Translate the high-level thinking mode into agno's ``thinking`` dict.
+
+    Agno's ``Claude`` class accepts a ``thinking`` parameter shaped like
+    ``{"type": "enabled", "budget_tokens": N}`` for extended thinking and
+    ``{"type": "adaptive"}`` for adaptive thinking. ``None`` disables it.
+
+    Args:
+        thinking_mode: One of "off", "extended", or "adaptive".
+        thinking_budget_tokens: Token budget for extended thinking. Required
+            when ``thinking_mode`` is "extended"; ignored otherwise.
+
+    Returns:
+        Dict to pass to ``Claude(thinking=...)``, or ``None`` when disabled.
+    """
+    if thinking_mode == "off":
+        return None
+
+    if thinking_mode == "adaptive":
+        return {"type": "adaptive"}
+
+    return {"type": "enabled", "budget_tokens": thinking_budget_tokens}
 
 
 class AnthropicModelSpec(AgnoSpec):
@@ -27,6 +58,13 @@ class AnthropicModelSpec(AgnoSpec):
         top_p: Nucleus sampling parameter.
         top_k: Top-k sampling parameter.
         stop_sequences: Stop sequences to end generation.
+        thinking_mode: Extended-thinking mode. ``"off"`` disables thinking,
+            ``"extended"`` enables Anthropic's extended thinking with a fixed
+            token budget, and ``"adaptive"`` lets the model pick its own
+            thinking budget per turn.
+        thinking_budget_tokens: Token budget for extended thinking. Required
+            (positive int) when ``thinking_mode == "extended"``; must be
+            ``None`` for the other modes.
     """
 
     type: Literal["anthropic"] = "anthropic"
@@ -37,6 +75,8 @@ class AnthropicModelSpec(AgnoSpec):
     top_p: float | None = None
     top_k: int | None = None
     stop_sequences: list[str] | None = None
+    thinking_mode: ThinkingMode = "off"
+    thinking_budget_tokens: int | None = None
 
 
 class AnthropicModelConfig(ModelConfig):
@@ -51,6 +91,15 @@ class AnthropicModelConfig(ModelConfig):
         top_p: Nucleus sampling parameter. Optional.
         top_k: Top-k sampling parameter. Optional.
         stop_sequences: Stop sequences to end generation. Optional.
+        thinking_mode: Extended-thinking mode. Defaults to ``"off"``. Set to
+            ``"extended"`` to enable Anthropic extended thinking with a fixed
+            ``thinking_budget_tokens`` budget, or ``"adaptive"`` to let the
+            model pick its own budget per turn. Note that some Claude model
+            ids (e.g. Claude 3 / 3.5 Haiku families) do not support thinking;
+            agno will reject the combination at runtime.
+        thinking_budget_tokens: Token budget when ``thinking_mode`` is
+            ``"extended"``. Required (positive integer) in that mode and must
+            be omitted for ``"off"`` and ``"adaptive"``.
     """
 
     api_key: SensitiveField[str]
@@ -59,6 +108,33 @@ class AnthropicModelConfig(ModelConfig):
     top_p: Field[float] | None = None
     top_k: Field[int] | None = None
     stop_sequences: Field[list[str]] | None = None
+    thinking_mode: Field[ThinkingMode] = "off"
+    thinking_budget_tokens: Field[int] | None = None
+
+    @model_validator(mode="after")
+    def validate_thinking_budget(self) -> AnthropicModelConfig:
+        """Enforce that ``thinking_budget_tokens`` matches ``thinking_mode``.
+
+        ``"extended"`` requires a positive ``thinking_budget_tokens``;
+        ``"off"`` and ``"adaptive"`` reject any budget so the catalog cannot
+        accidentally silently drop a configured budget when switching modes.
+
+        Returns:
+            Self after validation.
+
+        Raises:
+            ValueError: If the budget is missing/non-positive for
+                ``"extended"``, or set for ``"off"`` / ``"adaptive"``.
+        """
+        if self.thinking_mode == "extended":
+            if self.thinking_budget_tokens is None or self.thinking_budget_tokens <= 0:
+                msg = "thinking_budget_tokens must be a positive integer when thinking_mode is 'extended'"
+                raise ValueError(msg)
+        elif self.thinking_budget_tokens is not None:
+            msg = f"thinking_budget_tokens must be None when thinking_mode is {self.thinking_mode!r}"
+            raise ValueError(msg)
+
+        return self
 
 
 class AnthropicModelOutputs(ModelOutputs):
@@ -94,13 +170,29 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
     def from_spec(spec: AnthropicModelSpec) -> Claude:
         """Factory: construct Agno Claude object from spec.
 
+        ``thinking_mode`` and ``thinking_budget_tokens`` are translated into
+        the ``thinking`` dict shape that ``agno.models.anthropic.Claude``
+        expects (``{"type": "enabled", "budget_tokens": N}`` for extended
+        thinking, ``{"type": "adaptive"}`` for adaptive). The high-level
+        fields are not forwarded as kwargs because Claude does not accept
+        them directly.
+
         Args:
             spec: The model specification.
 
         Returns:
             Configured Claude instance ready for use.
         """
-        return Claude(**spec.model_dump(exclude={"type"}, exclude_none=True))
+        kwargs = spec.model_dump(
+            exclude={"type", "thinking_mode", "thinking_budget_tokens"},
+            exclude_none=True,
+        )
+
+        thinking = _build_thinking_param(spec.thinking_mode, spec.thinking_budget_tokens)
+        if thinking is not None:
+            kwargs["thinking"] = thinking
+
+        return Claude(**kwargs)
 
     def _build_spec(self) -> AnthropicModelSpec:
         """Build spec from current config.
@@ -119,6 +211,8 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
             top_p=self.config.top_p,
             top_k=self.config.top_k,
             stop_sequences=self.config.stop_sequences,
+            thinking_mode=self.config.thinking_mode,
+            thinking_budget_tokens=self.config.thinking_budget_tokens,
         )
 
     def _build_outputs(self) -> AnthropicModelOutputs:

--- a/packages/agno/src/agno_provider/resources/models/anthropic.py
+++ b/packages/agno/src/agno_provider/resources/models/anthropic.py
@@ -177,8 +177,24 @@ class AnthropicModelSpec(AgnoSpec):
 
         Returns:
             Self after validation.
+
+        Raises:
+            ValueError: If ``thinking_budget_tokens`` is greater than or
+                equal to ``max_tokens``.
         """
         _validate_thinking_fields(self.thinking_mode, self.thinking_budget_tokens, self.effort)
+
+        if (
+            self.thinking_budget_tokens is not None
+            and self.max_tokens is not None
+            and self.thinking_budget_tokens >= self.max_tokens
+        ):
+            msg = (
+                f"thinking_budget_tokens ({self.thinking_budget_tokens}) must be less "
+                f"than max_tokens ({self.max_tokens}) (Anthropic API constraint)"
+            )
+            raise ValueError(msg)
+
         return self
 
 
@@ -226,10 +242,31 @@ class AnthropicModelConfig(ModelConfig):
     def validate_thinking_fields(self) -> AnthropicModelConfig:
         """Enforce per-mode constraints on thinking-related fields.
 
+        The ``budget < max_tokens`` check only fires when both fields are
+        concrete integers. If either is a ``FieldReference`` it is left
+        for the resolved Spec to validate.
+
         Returns:
             Self after validation.
+
+        Raises:
+            ValueError: If both ``thinking_budget_tokens`` and ``max_tokens``
+                are concrete integers and the budget is greater than or
+                equal to ``max_tokens``.
         """
         _validate_thinking_fields(self.thinking_mode, self.thinking_budget_tokens, self.effort)
+
+        if (
+            isinstance(self.thinking_budget_tokens, int)
+            and isinstance(self.max_tokens, int)
+            and self.thinking_budget_tokens >= self.max_tokens
+        ):
+            msg = (
+                f"thinking_budget_tokens ({self.thinking_budget_tokens}) must be less "
+                f"than max_tokens ({self.max_tokens}) (Anthropic API constraint)"
+            )
+            raise ValueError(msg)
+
         return self
 
 
@@ -383,7 +420,12 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
         await client.models.retrieve(self.config.id)
 
     async def on_update(self, previous_config: AnthropicModelConfig) -> AnthropicModelOutputs:  # noqa: ARG002
-        """Update returns serializable outputs with spec.
+        """Validate model/mode compatibility and return serializable outputs with spec.
+
+        Re-runs the model/thinking-mode compatibility check so updating an
+        existing resource to an unsupported combination (e.g. switching
+        ``thinking_mode`` to ``"extended"`` on ``claude-opus-4-7``) fails
+        the update rather than silently propagating to the runner pod.
 
         Args:
             previous_config: The previous configuration (unused for stateless resource).
@@ -391,6 +433,7 @@ class AnthropicModel(Model[AnthropicModelConfig, AnthropicModelOutputs, Anthropi
         Returns:
             AnthropicModelOutputs with spec.
         """
+        self._validate_model_thinking_compatibility()
         return self._build_outputs()
 
     async def on_delete(self) -> None:

--- a/packages/agno/src/agno_provider/resources/models/anthropic.py
+++ b/packages/agno/src/agno_provider/resources/models/anthropic.py
@@ -93,9 +93,9 @@ def _validate_thinking_fields(
     """Enforce per-mode constraints on thinking-related fields.
 
     ``"off"`` rejects both ``thinking_budget_tokens`` and ``effort``.
-    ``"extended"`` requires a positive ``thinking_budget_tokens`` and rejects
-    ``effort``. ``"adaptive"`` rejects ``thinking_budget_tokens`` and accepts
-    optional ``effort``.
+    ``"extended"`` requires ``thinking_budget_tokens >= 1024`` (Anthropic API
+    minimum) and rejects ``effort``. ``"adaptive"`` rejects
+    ``thinking_budget_tokens`` and accepts optional ``effort``.
 
     Args:
         thinking_mode: One of "off", "extended", or "adaptive".
@@ -104,7 +104,7 @@ def _validate_thinking_fields(
 
     Raises:
         ValueError: If any field is set in a mode that does not accept it,
-            or if ``thinking_budget_tokens`` is missing/non-positive in
+            or if ``thinking_budget_tokens`` is missing/below 1024 in
             ``"extended"`` mode.
     """
     if thinking_mode == "off":
@@ -117,8 +117,8 @@ def _validate_thinking_fields(
         return
 
     if thinking_mode == "extended":
-        if thinking_budget_tokens is None or thinking_budget_tokens <= 0:
-            msg = "thinking_budget_tokens must be a positive integer when thinking_mode is 'extended'"
+        if thinking_budget_tokens is None or thinking_budget_tokens < 1024:
+            msg = "extended thinking requires thinking_budget_tokens >= 1024 (Anthropic API minimum)"
             raise ValueError(msg)
         if effort is not None:
             msg = "effort must be None when thinking_mode is 'extended' (effort is only valid for 'adaptive')"
@@ -150,7 +150,8 @@ class AnthropicModelSpec(AgnoSpec):
             token budget, and ``"adaptive"`` lets the model pick its own
             thinking budget per turn.
         thinking_budget_tokens: Token budget for extended thinking. Required
-            (positive int) when ``thinking_mode == "extended"``; must be
+            when ``thinking_mode == "extended"``; must be ``>= 1024``
+            (Anthropic API minimum) and less than ``max_tokens``. Must be
             ``None`` for the other modes.
         effort: Effort knob for ``"adaptive"`` thinking. Only valid when
             ``thinking_mode == "adaptive"``; must be ``None`` for the other
@@ -201,8 +202,9 @@ class AnthropicModelConfig(ModelConfig):
             (e.g. ``claude-opus-4-7`` is adaptive-only; ``claude-haiku-4-5``
             is extended-only).
         thinking_budget_tokens: Token budget when ``thinking_mode`` is
-            ``"extended"``. Required (positive integer) in that mode and must
-            be omitted for ``"off"`` and ``"adaptive"``.
+            ``"extended"``. Required in that mode and must be ``>= 1024``
+            (Anthropic API minimum) and less than ``max_tokens``. Must be
+            omitted for ``"off"`` and ``"adaptive"``.
         effort: Effort knob when ``thinking_mode`` is ``"adaptive"``. One of
             ``"low"``, ``"medium"``, ``"high"``, ``"xhigh"``, ``"max"``. Must
             be omitted for ``"off"`` and ``"extended"``. When omitted in


### PR DESCRIPTION
## Summary

Adds two new optional fields on the `agno/models/anthropic` resource to expose Anthropic's extended-thinking feature through the agno provider. This is the foundation for PRA-329 and the upcoming aggressiveness knob on `performance_profile`, where the catalog/seeding (in `pragma-os/api`) will pick a thinking mode per tier.

Schema:

```python
thinking_mode: Literal["off", "extended", "adaptive"] = "off"
thinking_budget_tokens: int | None = None
```

Validation:

- `"extended"` requires a positive integer `thinking_budget_tokens`
- `"off"` and `"adaptive"` reject any budget (catches accidentally leaving a budget set when toggling modes)
- Default `"off"` keeps every existing caller behaving identically — no migrations, no shims

## How thinking flows to the runner pod

1. `AnthropicModel.on_create` / `on_update` build `AnthropicModelSpec` including the two new fields.
2. `Runner._build_kubernetes_deployment` already serializes `agent.outputs.spec` via `model_dump(mode="json")` into `AGNO_SPECS_JSON`, so the fields ride along automatically — no runner changes needed.
3. In the pod, `agno_runner.server` reconstructs `AgentSpec.model_validate(...)` then `Agent.from_spec(spec)` which calls `model_from_spec(spec.model_spec)` -> `AnthropicModel.from_spec(spec)`.
4. `from_spec` translates the high-level fields into agno's `thinking` dict before instantiating `Claude`:
   - `"off"`      -> argument omitted (default `None` on agno's side)
   - `"extended"` -> `thinking={"type": "enabled", "budget_tokens": N}`
   - `"adaptive"` -> `thinking={"type": "adaptive"}`

The dict shape matches both [Anthropic's `ThinkingConfigParam`](https://github.com/anthropics/anthropic-sdk-python) (`ThinkingConfigEnabled` / `ThinkingConfigAdaptive`) and [agno's `Claude.thinking`](https://docs.agno.com) parameter (`Optional[Dict[str, Any]]`, validated by `_validate_thinking_support`).

## Caveats

agno's `Claude._validate_thinking_support` rejects `thinking` on Claude 3 / Claude 3.5 Haiku model ids (`claude-3-haiku-20240307`, `claude-3-5-haiku-20241022`, `claude-3-5-haiku-latest`). The catalog seeding work that follows this PR must pick haiku model ids that actually support thinking when the matrix calls for "haiku, extended thinking"; otherwise the runner will fail at agent reconstruction with a clear `ValueError` from agno.

## Test plan

- [x] All three modes validate: `off` (default), `extended` with positive budget, `adaptive`
- [x] Validator rejects: `extended` without budget, `extended` with zero/negative budget, `off` with budget set, `adaptive` with budget set, unknown mode literal
- [x] `AnthropicModelSpec` JSON round-trip preserves both fields (this is what the runner pod sees)
- [x] `AnthropicModel.from_spec` produces the correct `Claude.thinking` dict for each mode
- [x] `task agno:format` clean; `ruff check` clean (`task agno:check` baseline failures are unrelated `ty` import-resolution noise on sibling packages — see workspace memory)

## Out of scope (separate work)

- Catalog/seeding changes in `pragma-os/api` — picks model id + thinking mode per tier
- Per-organization `performance_profile` becoming the aggressiveness knob