### PR TITLE
chore: gitignore .claude/settings.local.json and drop stale CLAUDE.md note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ venv/
 # E2E test files (local testing only)
 e2e-test-*.yaml
 e2e/
+
+# Claude Code local settings (per-machine, not committed)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 # CLAUDE.md
 
-> Tasks tracked in Linear. SessionStart hook injects issue context from branch name.
-
 ## Project
 
 **pragma-providers**: Official providers for the Pragmatiks platform (GCP, AWS, etc.).


### PR DESCRIPTION
## Summary
- Add `.claude/settings.local.json` to `.gitignore` so per-machine Claude Code settings stay local.
- Remove a stale `CLAUDE.md` note that referenced a SessionStart hook that no longer exists.

Part of a workspace refactor: each repo now stands on its own with its own Claude Code config (no wrapper folder).

## Test plan
- [x] No code changes — only `.gitignore` and `CLAUDE.md` updates.