### PR TITLE
feat!: migrate platform providers to wheel-based publish flow (PRA-377)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -85,6 +85,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -166,16 +167,18 @@ jobs:
           skip-existing: true
           attestations: false
 
+      - name: Authenticate to Google Cloud
+        if: steps.bump.outputs.version != ''
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            gcp \
-            "dist/pragmatiks_gcp_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/gcp/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/gcp
 
   publish-supabase:
     needs: [detect-changes]
@@ -189,6 +192,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -270,16 +274,18 @@ jobs:
           skip-existing: true
           attestations: false
 
+      - name: Authenticate to Google Cloud
+        if: steps.bump.outputs.version != ''
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            supabase \
-            "dist/pragmatiks_supabase_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/supabase/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/supabase
 
   publish-vercel:
     needs: [detect-changes]
@@ -293,6 +299,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -374,16 +381,18 @@ jobs:
           skip-existing: true
           attestations: false
 
+      - name: Authenticate to Google Cloud
+        if: steps.bump.outputs.version != ''
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            vercel \
-            "dist/pragmatiks_vercel_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/vercel/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/vercel
 
   publish-github:
     needs: [detect-changes]
@@ -397,6 +406,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -478,16 +488,18 @@ jobs:
           skip-existing: true
           attestations: false
 
+      - name: Authenticate to Google Cloud
+        if: steps.bump.outputs.version != ''
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            github \
-            "dist/pragmatiks_github_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/github/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/github
 
   publish-pragma:
     needs: [detect-changes]
@@ -501,6 +513,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -582,16 +595,18 @@ jobs:
           skip-existing: true
           attestations: false
 
+      - name: Authenticate to Google Cloud
+        if: steps.bump.outputs.version != ''
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            pragma \
-            "dist/pragmatiks_pragma_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/pragma/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/pragma
 
   publish-kubernetes:
     needs: [detect-changes, publish-gcp]
@@ -617,6 +632,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -718,16 +734,18 @@ jobs:
           skip-existing: true
           attestations: false
 
+      - name: Authenticate to Google Cloud
+        if: steps.bump.outputs.version != ''
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            kubernetes \
-            "dist/pragmatiks_kubernetes_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/kubernetes/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/kubernetes
 
   publish-qdrant:
     needs: [detect-changes, publish-kubernetes]
@@ -752,6 +770,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -853,16 +872,18 @@ jobs:
           skip-existing: true
           attestations: false
 
+      - name: Authenticate to Google Cloud
+        if: steps.bump.outputs.version != ''
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            qdrant \
-            "dist/pragmatiks_qdrant_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/qdrant/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/qdrant
 
   publish-agno:
     needs: [detect-changes, publish-gcp, publish-kubernetes]
@@ -888,6 +909,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
       packages: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
@@ -999,16 +1021,18 @@ jobs:
           skip-existing: true
           attestations: false
 
+      - name: Authenticate to Google Cloud
+        if: steps.bump.outputs.version != ''
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
       - name: Publish to pragma store
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            agno \
-            "dist/pragmatiks_agno_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/agno/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/agno
 
       - name: Read runner transport version
         id: runner-transport

--- a/packages/agno/pyproject.toml
+++ b/packages/agno/pyproject.toml
@@ -36,6 +36,7 @@ display_name = "Agno AI Agents"
 description = "Build and deploy AI agents, teams, and knowledge bases with models from OpenAI and Anthropic, MCP tools, and vector storage."
 icon_url = "https://cdn.prod.website-files.com/6796d350b8c706e4533e7e32/68a85d04c4b355c4accb0f9f_256.png"
 tags = ["ai", "agents", "llm", "openai", "anthropic", "knowledge-base"]
+entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/gcp/pyproject.toml
+++ b/packages/gcp/pyproject.toml
@@ -34,6 +34,7 @@ display_name = "Google Cloud Platform"
 description = "Manage GCP resources including Cloud SQL databases, GKE clusters, and secrets through declarative configuration."
 icon_url = "https://cdn.simpleicons.org/googlecloud"
 tags = ["cloud", "gcp", "infrastructure", "database", "kubernetes"]
+entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/github/pyproject.toml
+++ b/packages/github/pyproject.toml
@@ -32,6 +32,7 @@ display_name = "GitHub"
 description = "Manage GitHub repositories, environments, and secrets through declarative resources using the GitHub REST API."
 icon_url = "https://cdn.simpleicons.org/github"
 tags = ["github", "repositories", "secrets", "environments", "source-control"]
+entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/kubernetes/pyproject.toml
+++ b/packages/kubernetes/pyproject.toml
@@ -33,6 +33,7 @@ display_name = "Kubernetes"
 description = "Deploy and manage Kubernetes resources including deployments, services, configmaps, secrets, and statefulsets."
 icon_url = "https://cdn.simpleicons.org/kubernetes"
 tags = ["kubernetes", "orchestration", "containers", "infrastructure"]
+entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/pragma/pyproject.toml
+++ b/packages/pragma/pyproject.toml
@@ -29,6 +29,7 @@ display_name = "Pragma Platform"
 description = "Manage platform-native secrets, configuration, and file storage declaratively through Pragmatiks."
 icon_url = "https://pragmatiks.io/icon.svg"
 tags = ["platform", "secrets", "configuration", "files"]
+entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/qdrant/pyproject.toml
+++ b/packages/qdrant/pyproject.toml
@@ -31,6 +31,7 @@ display_name = "Qdrant Vector Database"
 description = "Provision and manage Qdrant vector database instances and collections for similarity search and AI applications."
 icon_url = "https://cdn.simpleicons.org/qdrant"
 tags = ["vector-database", "search", "ai", "embeddings"]
+entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/supabase/pyproject.toml
+++ b/packages/supabase/pyproject.toml
@@ -31,6 +31,7 @@ display_name = "Supabase"
 description = "Manage Supabase projects and configuration through declarative resources using the Management API."
 icon_url = "https://cdn.simpleicons.org/supabase"
 tags = ["supabase", "database", "authentication", "backend-as-a-service"]
+entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/packages/vercel/pyproject.toml
+++ b/packages/vercel/pyproject.toml
@@ -31,6 +31,7 @@ display_name = "Vercel"
 description = "Manage Vercel projects, deployments, and domains through declarative resources using the Vercel REST API."
 icon_url = "https://cdn.simpleicons.org/vercel"
 tags = ["vercel", "hosting", "deployments", "domains", "frontend"]
+entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/scripts/publish_platform_provider.sh
+++ b/scripts/publish_platform_provider.sh
@@ -1,125 +1,64 @@
 #!/usr/bin/env bash
 #
-# Publish a platform provider tarball to api.pragmatiks.io via the
-# ConsoleMachine-authenticated /console/providers/{name}/publish endpoint.
+# Publish a platform provider wheel to api.pragmatiks.io and to the
+# Pragmatiks Artifact Registry Python repo via the Pragmatiks CLI.
 #
 # Mints a fresh short-lived Clerk M2M token (mt_...) from the long-lived
-# Clerk Machine Secret (ak_...) for each call, then POSTs the tarball as
-# multipart/form-data. No long-lived M2M token is kept in CI.
+# Clerk Machine Secret (ak_...) and exports it as PRAGMA_AUTH_TOKEN so
+# the CLI authenticates as the ConsoleMachine identity. The CLI then:
+#   - Builds the wheel from the provider source tree with `uv build`.
+#   - Uploads the wheel to GCP Artifact Registry with `uv publish`,
+#     using `keyrings.google-artifactregistry-auth` to resolve
+#     credentials from Application Default Credentials.
+#   - Posts a metadata record to POST /provider-versions on the API.
 #
 # Required env vars:
 #   PRAGMA_CONSOLE_MACHINE_SECRET_KEY  Clerk Machine Secret (ak_...) for
 #                                      the Pragmatiks Console "ci-release"
 #                                      Machine.
 #
+# The runner must also have Application Default Credentials available
+# for the Artifact Registry upload (Workload Identity Federation in
+# CI; `gcloud auth application-default login` locally).
+#
 # Optional env vars:
-#   API_BASE_URL                       Default: https://api.pragmatiks.io
-#   MINT_TTL_SECONDS                   Default: 3600 (max 7200)
+#   MINT_TTL_SECONDS                   Default: 3600 (max 7200).
+#   PRAGMA_CLI_VERSION                 Default: >=3.0.0. Version
+#                                      specifier passed to `uv run
+#                                      --with pragmatiks-cli<spec>`.
+#
+# To target a non-prod API, configure a CLI context with the desired
+# api_url before invoking this script (e.g. `pragma config set-context
+# staging --api-url https://api.staging.pragmatiks.io`) and pass
+# `--context staging` through PRAGMA_CONTEXT.
 #
 # Usage:
-#   publish_platform_provider.sh <provider_short_name> <tarball_path> <version> <pyproject_path>
-#
-# The pyproject_path points at the provider's pyproject.toml. Provider
-# metadata (display_name, description, icon_url, tags) is read from the
-# [tool.pragma] table and forwarded to the API as form fields.
+#   publish_platform_provider.sh <provider_dir>
 #
 # Example:
-#   publish_platform_provider.sh \
-#     gcp \
-#     dist/pragmatiks_gcp_provider-0.173.0.tar.gz \
-#     0.173.0 \
-#     packages/gcp/pyproject.toml
+#   publish_platform_provider.sh packages/gcp
 
 set -euo pipefail
 
-PROVIDER_NAME="${1:?provider_short_name argument is required (e.g. gcp)}"
-TARBALL_PATH="${2:?tarball_path argument is required}"
-VERSION="${3:?version argument is required}"
-PYPROJECT_PATH="${4:?pyproject_path argument is required (e.g. packages/gcp/pyproject.toml)}"
+PROVIDER_DIR="${1:?provider_dir argument is required (e.g. packages/gcp)}"
 
-API_BASE_URL="${API_BASE_URL:-https://api.pragmatiks.io}"
 MINT_TTL_SECONDS="${MINT_TTL_SECONDS:-3600}"
+PRAGMA_CLI_VERSION="${PRAGMA_CLI_VERSION:->=3.0.0}"
 
 if [ -z "${PRAGMA_CONSOLE_MACHINE_SECRET_KEY:-}" ]; then
   echo "publish_platform_provider: PRAGMA_CONSOLE_MACHINE_SECRET_KEY is empty or unset" >&2
   exit 1
 fi
 
-if [ ! -f "${TARBALL_PATH}" ]; then
-  echo "publish_platform_provider: tarball not found at ${TARBALL_PATH}" >&2
+if [ ! -d "${PROVIDER_DIR}" ]; then
+  echo "publish_platform_provider: provider directory not found at ${PROVIDER_DIR}" >&2
   exit 1
 fi
 
-if [ ! -f "${PYPROJECT_PATH}" ]; then
-  echo "publish_platform_provider: pyproject not found at ${PYPROJECT_PATH}" >&2
+if [ ! -f "${PROVIDER_DIR}/pyproject.toml" ]; then
+  echo "publish_platform_provider: ${PROVIDER_DIR}/pyproject.toml not found" >&2
   exit 1
 fi
-
-echo "Reading provider metadata from ${PYPROJECT_PATH}..."
-
-if ! METADATA=$(
-  PYPROJECT_PATH="${PYPROJECT_PATH}" \
-  uv run --isolated python -c '
-import json
-import os
-import sys
-import tomllib
-
-path = os.environ["PYPROJECT_PATH"]
-with open(path, "rb") as f:
-    data = tomllib.load(f)
-
-pragma = data.get("tool", {}).get("pragma", {})
-
-display_name = pragma.get("display_name")
-description = pragma.get("description")
-if not display_name or not description:
-    sys.stderr.write(
-        f"{path}: [tool.pragma] must define both display_name and description\n"
-    )
-    sys.exit(1)
-
-icon_url = pragma.get("icon_url") or ""
-tags = pragma.get("tags") or []
-if not isinstance(tags, list):
-    sys.stderr.write(f"{path}: [tool.pragma].tags must be an array\n")
-    sys.exit(1)
-tags_json = json.dumps(tags) if tags else ""
-
-# Emit shell-evaluable lines: KEY=<base64-encoded value>. Base64 keeps
-# arbitrary characters (quotes, newlines, shell metachars) safe across
-# the bash boundary.
-import base64
-
-def emit(key: str, value: str) -> None:
-    encoded = base64.b64encode(value.encode("utf-8")).decode("ascii")
-    sys.stdout.write(f"{key}={encoded}\n")
-
-emit("DISPLAY_NAME", display_name)
-emit("DESCRIPTION", description)
-emit("ICON_URL", icon_url)
-emit("TAGS_JSON", tags_json)
-'
-); then
-  echo "publish_platform_provider: failed to read metadata from ${PYPROJECT_PATH}" >&2
-  exit 1
-fi
-
-decode_meta() {
-  local key="$1"
-  local line
-  line=$(printf '%s\n' "${METADATA}" | grep "^${key}=" || true)
-  if [ -z "${line}" ]; then
-    echo ""
-    return
-  fi
-  printf '%s' "${line#${key}=}" | base64 --decode
-}
-
-DISPLAY_NAME=$(decode_meta DISPLAY_NAME)
-DESCRIPTION=$(decode_meta DESCRIPTION)
-ICON_URL=$(decode_meta ICON_URL)
-TAGS_JSON=$(decode_meta TAGS_JSON)
 
 echo "Minting ConsoleMachine M2M token (ttl=${MINT_TTL_SECONDS}s)..."
 
@@ -165,44 +104,16 @@ if [ -z "${TOKEN}" ]; then
 fi
 
 echo "::add-mask::${TOKEN}"
-echo "Minted token (length=${#TOKEN}). Posting ${TARBALL_PATH} to ${API_BASE_URL}..."
+echo "Minted token (length=${#TOKEN}). Publishing ${PROVIDER_DIR} via pragma CLI..."
 
-RESPONSE_BODY="$(mktemp)"
-trap 'rm -f "${MINT_STDERR}" "${RESPONSE_BODY}"' EXIT
-
-CURL_FORM_ARGS=(
-  -F "version=${VERSION}"
-  -F "display_name=${DISPLAY_NAME}"
-  -F "description=${DESCRIPTION}"
-)
-
-# Optional fields are omitted entirely when empty so the API form parser
-# treats them as absent rather than empty strings.
-if [ -n "${ICON_URL}" ]; then
-  CURL_FORM_ARGS+=(-F "icon_url=${ICON_URL}")
-fi
-if [ -n "${TAGS_JSON}" ]; then
-  CURL_FORM_ARGS+=(-F "tags=${TAGS_JSON}")
-fi
-
-CURL_FORM_ARGS+=(-F "code=@${TARBALL_PATH};type=application/gzip")
-
-HTTP_CODE=$(
-  curl -sS \
-    -o "${RESPONSE_BODY}" \
-    -w '%{http_code}' \
-    -X POST "${API_BASE_URL}/console/providers/${PROVIDER_NAME}/publish" \
-    -H "Authorization: Bearer ${TOKEN}" \
-    "${CURL_FORM_ARGS[@]}"
-)
-
-if [ "${HTTP_CODE}" -lt 200 ] || [ "${HTTP_CODE}" -ge 300 ]; then
-  echo "publish_platform_provider: API returned HTTP ${HTTP_CODE}" >&2
-  cat "${RESPONSE_BODY}" >&2
-  echo >&2
-  exit 1
-fi
-
-echo "Published platform/${PROVIDER_NAME} v${VERSION} (HTTP ${HTTP_CODE})"
-cat "${RESPONSE_BODY}"
-echo
+# `uv run --with` builds an ephemeral env that includes:
+#   - pragmatiks-cli (the publishing CLI itself).
+#   - keyrings.google-artifactregistry-auth (so `uv publish` inside the
+#     CLI can resolve GAR credentials from Application Default
+#     Credentials).
+# The CLI inherits PRAGMA_AUTH_TOKEN from the parent shell.
+PRAGMA_AUTH_TOKEN="${TOKEN}" \
+uv run --isolated \
+  --with "pragmatiks-cli${PRAGMA_CLI_VERSION}" \
+  --with "keyrings.google-artifactregistry-auth" \
+  pragma providers publish --directory "${PROVIDER_DIR}"


### PR DESCRIPTION
## Summary

Migrates all 8 platform providers from the legacy multipart-tarball publish flow to the wheel-based `POST /provider-versions` flow introduced in [PRA-376](https://linear.app/pragmatiks/issue/PRA-376) (`pragmatiks-sdk@3.0.0`, `pragmatiks-cli@3.0.0`).

[PRA-377](https://linear.app/pragmatiks/issue/PRA-377-pragma-providers-migrate-platform-providers-gcpkubernetesqdrantagno-to) — closes [pragma-providers#80](https://github.com/pragmatiks/pragma-providers/issues/80).

## What changes

- **Per-provider pyproject.toml** — every provider (`agno`, `gcp`, `github`, `kubernetes`, `pragma`, `qdrant`, `supabase`, `vercel`) declares `entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]` under `[tool.pragma]`. This is the runtime resolver's default; declaring it explicitly forwards the value through the new API payload so future runtimes can override per-provider without code changes.
- **`scripts/publish_platform_provider.sh`** — collapses to a single-arg `<provider_dir>` script. Mints the Clerk M2M token as before, exports it as `PRAGMA_AUTH_TOKEN`, then shells out to `pragma providers publish --directory <dir>`. The CLI handles wheel build (`uv build`), Artifact Registry upload (`uv publish`, auth via `keyrings.google-artifactregistry-auth` + ADC), and the API POST.
- **`.github/workflows/publish.yaml`** — every provider job adds `id-token: write` and a `google-github-actions/auth@v2` step before "Publish to pragma store" so OIDC-based Workload Identity Federation can authenticate the wheel upload.

The issue named only `gcp/kubernetes/qdrant/agno` but the publish flow is provider-agnostic, so migrating all 8 in one swing avoids leaving a stale legacy script around.

## Required before merge

Two repository secrets need to exist (same shape as `pragma-os`):

- `GCP_WORKLOAD_IDENTITY_PROVIDER` — full provider resource name.
- `GCP_SERVICE_ACCOUNT` — the publisher GSA, must hold `roles/artifactregistry.writer` on `europe-west4-python.pkg.dev/pragmatiks-prod/pragma-providers`.

The PyPI publish step is unchanged — providers still ship to PyPI for cross-provider dependency resolution; the wheel goes to Artifact Registry as a separate distribution channel.

## Test plan

- [ ] Confirm `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_SERVICE_ACCOUNT` secrets exist on this repo and the publisher GSA has `roles/artifactregistry.writer`.
- [ ] Trigger `Publish Providers` via `workflow_dispatch` on a single provider (recommend `gcp` first per the rollout order in the runbook) and confirm:
  - `Authenticate to Google Cloud` succeeds.
  - `Publish to pragma store` exits zero.
  - The wheel appears in the Artifact Registry repo.
  - The provider version is registered on the API.
- [ ] Boot a runtime container with `PRAGMA_PROVIDER_WHEEL=<the published wheel URL>` and confirm the provider initialises.
- [ ] Run the per-provider e2e suite against the wheel-installed runtime.
- [ ] Repeat for `qdrant`, `kubernetes`, `agno`, `supabase`, `vercel`, `github`, `pragma`.