### PR TITLE
feat!: register PyPI wheel via pragma CLI, switch PyPI auth to OIDC (PRA-382)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -85,6 +85,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -162,7 +163,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-          password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true
           attestations: false
 
@@ -170,12 +170,7 @@ jobs:
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            gcp \
-            "dist/pragmatiks_gcp_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/gcp/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/gcp "${{ steps.bump.outputs.version }}"
 
   publish-supabase:
     needs: [detect-changes]
@@ -189,6 +184,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -266,7 +262,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-          password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true
           attestations: false
 
@@ -274,12 +269,7 @@ jobs:
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            supabase \
-            "dist/pragmatiks_supabase_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/supabase/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/supabase "${{ steps.bump.outputs.version }}"
 
   publish-vercel:
     needs: [detect-changes]
@@ -293,6 +283,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -370,7 +361,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-          password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true
           attestations: false
 
@@ -378,12 +368,7 @@ jobs:
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            vercel \
-            "dist/pragmatiks_vercel_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/vercel/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/vercel "${{ steps.bump.outputs.version }}"
 
   publish-github:
     needs: [detect-changes]
@@ -397,6 +382,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -474,7 +460,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-          password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true
           attestations: false
 
@@ -482,12 +467,7 @@ jobs:
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            github \
-            "dist/pragmatiks_github_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/github/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/github "${{ steps.bump.outputs.version }}"
 
   publish-pragma:
     needs: [detect-changes]
@@ -501,6 +481,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -578,7 +559,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-          password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true
           attestations: false
 
@@ -586,12 +566,7 @@ jobs:
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            pragma \
-            "dist/pragmatiks_pragma_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/pragma/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/pragma "${{ steps.bump.outputs.version }}"
 
   publish-kubernetes:
     needs: [detect-changes, publish-gcp]
@@ -617,6 +592,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -714,7 +690,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-          password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true
           attestations: false
 
@@ -722,12 +697,7 @@ jobs:
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            kubernetes \
-            "dist/pragmatiks_kubernetes_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/kubernetes/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/kubernetes "${{ steps.bump.outputs.version }}"
 
   publish-qdrant:
     needs: [detect-changes, publish-kubernetes]
@@ -752,6 +722,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -849,7 +820,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-          password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true
           attestations: false
 
@@ -857,12 +827,7 @@ jobs:
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            qdrant \
-            "dist/pragmatiks_qdrant_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/qdrant/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/qdrant "${{ steps.bump.outputs.version }}"
 
   publish-agno:
     needs: [detect-changes, publish-gcp, publish-kubernetes]
@@ -888,6 +853,7 @@ jobs:
     environment: pypi
     permissions:
       contents: write
+      id-token: write
       packages: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
@@ -995,7 +961,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-          password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true
           attestations: false
 
@@ -1003,12 +968,7 @@ jobs:
         if: steps.bump.outputs.version != ''
         env:
           PRAGMA_CONSOLE_MACHINE_SECRET_KEY: ${{ secrets.PRAGMA_CONSOLE_MACHINE_SECRET_KEY }}
-        run: |
-          ./scripts/publish_platform_provider.sh \
-            agno \
-            "dist/pragmatiks_agno_provider-${{ steps.bump.outputs.version }}.tar.gz" \
-            "${{ steps.bump.outputs.version }}" \
-            packages/agno/pyproject.toml
+        run: ./scripts/publish_platform_provider.sh packages/agno "${{ steps.bump.outputs.version }}"
 
       - name: Read runner transport version
         id: runner-transport

--- a/scripts/publish_platform_provider.sh
+++ b/scripts/publish_platform_provider.sh
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
 #
-# Publish a platform provider tarball to api.pragmatiks.io via the
-# ConsoleMachine-authenticated /console/providers/{name}/publish endpoint.
+# Register a platform provider version on api.pragmatiks.io using a wheel
+# already uploaded to PyPI.
 #
-# Mints a fresh short-lived Clerk M2M token (mt_...) from the long-lived
-# Clerk Machine Secret (ak_...) for each call, then POSTs the tarball as
-# multipart/form-data. No long-lived M2M token is kept in CI.
+# Assumes the wheel for `<dist-name>==<version>` (where `<dist-name>` is the
+# `[project].name` field of the provider's pyproject.toml) has just been
+# published to PyPI. The script:
+#   - Reads `[project].name` from the provider's pyproject.toml.
+#   - Polls https://pypi.org/pypi/<dist-name>/<version>/json until the
+#     wheel ("bdist_wheel") entry appears, then captures its `url` and
+#     `digests.sha256`.
+#   - Mints a fresh short-lived Clerk M2M token (mt_...) from the long-lived
+#     Clerk Machine Secret (ak_...), exports it as PRAGMA_AUTH_TOKEN, and
+#     invokes `pragma providers register` with the wheel URL, sha256,
+#     version, and pyproject path. The CLI reads the rest of the metadata
+#     (display_name, description, icon_url, tags, package, entrypoint) out
+#     of the [tool.pragma] table itself.
 #
 # Required env vars:
 #   PRAGMA_CONSOLE_MACHINE_SECRET_KEY  Clerk Machine Secret (ak_...) for
@@ -13,40 +23,39 @@
 #                                      Machine.
 #
 # Optional env vars:
-#   API_BASE_URL                       Default: https://api.pragmatiks.io
-#   MINT_TTL_SECONDS                   Default: 3600 (max 7200)
+#   MINT_TTL_SECONDS                   Default: 3600 (max 7200).
+#   PRAGMA_CLI_VERSION                 Default: >=3.0.0. Version specifier
+#                                      passed to `uv run --with
+#                                      pragmatiks-cli<spec>`.
+#   PYPI_POLL_ATTEMPTS                 Default: 30. Times to poll PyPI for
+#                                      wheel availability.
+#   PYPI_POLL_INTERVAL                 Default: 10. Seconds between polls.
+#
+# To target a non-prod API, configure a CLI context with the desired
+# api_url before invoking this script (e.g. `pragma config set-context
+# staging --api-url https://api.staging.pragmatiks.io`) and pass
+# `--context staging` through PRAGMA_CONTEXT.
 #
 # Usage:
-#   publish_platform_provider.sh <provider_short_name> <tarball_path> <version> <pyproject_path>
-#
-# The pyproject_path points at the provider's pyproject.toml. Provider
-# metadata (display_name, description, icon_url, tags) is read from the
-# [tool.pragma] table and forwarded to the API as form fields.
+#   publish_platform_provider.sh <provider_dir> <version>
 #
 # Example:
-#   publish_platform_provider.sh \
-#     gcp \
-#     dist/pragmatiks_gcp_provider-0.173.0.tar.gz \
-#     0.173.0 \
-#     packages/gcp/pyproject.toml
+#   publish_platform_provider.sh packages/gcp 0.186.0
 
 set -euo pipefail
 
-PROVIDER_NAME="${1:?provider_short_name argument is required (e.g. gcp)}"
-TARBALL_PATH="${2:?tarball_path argument is required}"
-VERSION="${3:?version argument is required}"
-PYPROJECT_PATH="${4:?pyproject_path argument is required (e.g. packages/gcp/pyproject.toml)}"
+PROVIDER_DIR="${1:?provider_dir argument is required (e.g. packages/gcp)}"
+VERSION="${2:?version argument is required}"
 
-API_BASE_URL="${API_BASE_URL:-https://api.pragmatiks.io}"
+PYPROJECT_PATH="${PROVIDER_DIR}/pyproject.toml"
+
+PRAGMA_CLI_VERSION="${PRAGMA_CLI_VERSION:->=3.0.0}"
 MINT_TTL_SECONDS="${MINT_TTL_SECONDS:-3600}"
+PYPI_POLL_ATTEMPTS="${PYPI_POLL_ATTEMPTS:-30}"
+PYPI_POLL_INTERVAL="${PYPI_POLL_INTERVAL:-10}"
 
 if [ -z "${PRAGMA_CONSOLE_MACHINE_SECRET_KEY:-}" ]; then
   echo "publish_platform_provider: PRAGMA_CONSOLE_MACHINE_SECRET_KEY is empty or unset" >&2
-  exit 1
-fi
-
-if [ ! -f "${TARBALL_PATH}" ]; then
-  echo "publish_platform_provider: tarball not found at ${TARBALL_PATH}" >&2
   exit 1
 fi
 
@@ -55,12 +64,11 @@ if [ ! -f "${PYPROJECT_PATH}" ]; then
   exit 1
 fi
 
-echo "Reading provider metadata from ${PYPROJECT_PATH}..."
+echo "Reading distribution name from ${PYPROJECT_PATH}..."
 
-if ! METADATA=$(
+if ! DIST_NAME=$(
   PYPROJECT_PATH="${PYPROJECT_PATH}" \
   uv run --isolated python -c '
-import json
 import os
 import sys
 import tomllib
@@ -69,62 +77,101 @@ path = os.environ["PYPROJECT_PATH"]
 with open(path, "rb") as f:
     data = tomllib.load(f)
 
-pragma = data.get("tool", {}).get("pragma", {})
-
-display_name = pragma.get("display_name")
-description = pragma.get("description")
-if not display_name or not description:
-    sys.stderr.write(
-        f"{path}: [tool.pragma] must define both display_name and description\n"
-    )
+name = data.get("project", {}).get("name")
+if not name:
+    sys.stderr.write(f"{path}: [project].name is missing\n")
     sys.exit(1)
 
-icon_url = pragma.get("icon_url") or ""
-tags = pragma.get("tags") or []
-if not isinstance(tags, list):
-    sys.stderr.write(f"{path}: [tool.pragma].tags must be an array\n")
-    sys.exit(1)
-tags_json = json.dumps(tags) if tags else ""
-
-# Emit shell-evaluable lines: KEY=<base64-encoded value>. Base64 keeps
-# arbitrary characters (quotes, newlines, shell metachars) safe across
-# the bash boundary.
-import base64
-
-def emit(key: str, value: str) -> None:
-    encoded = base64.b64encode(value.encode("utf-8")).decode("ascii")
-    sys.stdout.write(f"{key}={encoded}\n")
-
-emit("DISPLAY_NAME", display_name)
-emit("DESCRIPTION", description)
-emit("ICON_URL", icon_url)
-emit("TAGS_JSON", tags_json)
+sys.stdout.write(name)
 '
 ); then
-  echo "publish_platform_provider: failed to read metadata from ${PYPROJECT_PATH}" >&2
+  echo "publish_platform_provider: failed to read [project].name from ${PYPROJECT_PATH}" >&2
   exit 1
 fi
 
-decode_meta() {
-  local key="$1"
-  local line
-  line=$(printf '%s\n' "${METADATA}" | grep "^${key}=" || true)
-  if [ -z "${line}" ]; then
-    echo ""
-    return
-  fi
-  printf '%s' "${line#${key}=}" | base64 --decode
-}
+echo "Resolving wheel URL for ${DIST_NAME} v${VERSION} on PyPI..."
 
-DISPLAY_NAME=$(decode_meta DISPLAY_NAME)
-DESCRIPTION=$(decode_meta DESCRIPTION)
-ICON_URL=$(decode_meta ICON_URL)
-TAGS_JSON=$(decode_meta TAGS_JSON)
+PYPI_JSON_URL="https://pypi.org/pypi/${DIST_NAME}/${VERSION}/json"
+PYPI_RESPONSE="$(mktemp)"
+trap 'rm -f "${PYPI_RESPONSE}"' EXIT
+
+WHEEL_FOUND=0
+for attempt in $(seq 1 "${PYPI_POLL_ATTEMPTS}"); do
+  if curl -sfL -o "${PYPI_RESPONSE}" "${PYPI_JSON_URL}"; then
+    HAS_WHEEL=$(
+      PYPI_RESPONSE="${PYPI_RESPONSE}" uv run --isolated python -c '
+import json
+import os
+import sys
+
+with open(os.environ["PYPI_RESPONSE"], "rb") as f:
+    data = json.load(f)
+
+for entry in data.get("urls") or []:
+    if entry.get("packagetype") == "bdist_wheel":
+        sys.stdout.write("yes")
+        sys.exit(0)
+
+sys.stdout.write("no")
+'
+    )
+    if [ "${HAS_WHEEL}" = "yes" ]; then
+      WHEEL_FOUND=1
+      break
+    fi
+  fi
+  echo "Attempt ${attempt}: wheel not yet visible on PyPI, waiting ${PYPI_POLL_INTERVAL}s..."
+  sleep "${PYPI_POLL_INTERVAL}"
+done
+
+if [ "${WHEEL_FOUND}" -ne 1 ]; then
+  echo "publish_platform_provider: timed out waiting for ${DIST_NAME} v${VERSION} wheel on PyPI" >&2
+  exit 1
+fi
+
+if ! WHEEL_META=$(
+  PYPI_RESPONSE="${PYPI_RESPONSE}" uv run --isolated python -c '
+import json
+import os
+import sys
+
+with open(os.environ["PYPI_RESPONSE"], "rb") as f:
+    data = json.load(f)
+
+for entry in data.get("urls") or []:
+    if entry.get("packagetype") != "bdist_wheel":
+        continue
+    url = entry.get("url")
+    sha256 = (entry.get("digests") or {}).get("sha256")
+    if not url or not sha256:
+        sys.stderr.write("wheel entry is missing url or digests.sha256\n")
+        sys.exit(1)
+    sys.stdout.write(f"{url}\n{sha256}\n")
+    sys.exit(0)
+
+sys.stderr.write("no bdist_wheel entry found in PyPI response\n")
+sys.exit(1)
+'
+); then
+  echo "publish_platform_provider: failed to extract wheel metadata from PyPI response" >&2
+  exit 1
+fi
+
+WHEEL_URL=$(printf '%s\n' "${WHEEL_META}" | sed -n '1p')
+WHEEL_SHA256=$(printf '%s\n' "${WHEEL_META}" | sed -n '2p')
+
+if [ -z "${WHEEL_URL}" ] || [ -z "${WHEEL_SHA256}" ]; then
+  echo "publish_platform_provider: empty wheel URL or sha256" >&2
+  exit 1
+fi
+
+echo "Wheel URL: ${WHEEL_URL}"
+echo "Wheel sha256: ${WHEEL_SHA256}"
 
 echo "Minting ConsoleMachine M2M token (ttl=${MINT_TTL_SECONDS}s)..."
 
 MINT_STDERR="$(mktemp)"
-trap 'rm -f "${MINT_STDERR}"' EXIT
+trap 'rm -f "${PYPI_RESPONSE}" "${MINT_STDERR}"' EXIT
 
 if ! TOKEN=$(
   CONSOLE_CLERK_MACHINE_SECRET_KEY="${PRAGMA_CONSOLE_MACHINE_SECRET_KEY}" \
@@ -165,44 +212,19 @@ if [ -z "${TOKEN}" ]; then
 fi
 
 echo "::add-mask::${TOKEN}"
-echo "Minted token (length=${#TOKEN}). Posting ${TARBALL_PATH} to ${API_BASE_URL}..."
+echo "Minted token (length=${#TOKEN}). Registering ${DIST_NAME} v${VERSION} with Pragma catalog..."
 
-RESPONSE_BODY="$(mktemp)"
-trap 'rm -f "${MINT_STDERR}" "${RESPONSE_BODY}"' EXIT
-
-CURL_FORM_ARGS=(
-  -F "version=${VERSION}"
-  -F "display_name=${DISPLAY_NAME}"
-  -F "description=${DESCRIPTION}"
-)
-
-# Optional fields are omitted entirely when empty so the API form parser
-# treats them as absent rather than empty strings.
-if [ -n "${ICON_URL}" ]; then
-  CURL_FORM_ARGS+=(-F "icon_url=${ICON_URL}")
-fi
-if [ -n "${TAGS_JSON}" ]; then
-  CURL_FORM_ARGS+=(-F "tags=${TAGS_JSON}")
+CONTEXT_ARGS=()
+if [ -n "${PRAGMA_CONTEXT:-}" ]; then
+  CONTEXT_ARGS+=(--context "${PRAGMA_CONTEXT}")
 fi
 
-CURL_FORM_ARGS+=(-F "code=@${TARBALL_PATH};type=application/gzip")
+PRAGMA_AUTH_TOKEN="${TOKEN}" \
+  uv run --isolated --with "pragmatiks-cli${PRAGMA_CLI_VERSION}" \
+    pragma "${CONTEXT_ARGS[@]}" providers register \
+    --wheel-url "${WHEEL_URL}" \
+    --sha256 "${WHEEL_SHA256}" \
+    --version "${VERSION}" \
+    --pyproject "${PYPROJECT_PATH}"
 
-HTTP_CODE=$(
-  curl -sS \
-    -o "${RESPONSE_BODY}" \
-    -w '%{http_code}' \
-    -X POST "${API_BASE_URL}/console/providers/${PROVIDER_NAME}/publish" \
-    -H "Authorization: Bearer ${TOKEN}" \
-    "${CURL_FORM_ARGS[@]}"
-)
-
-if [ "${HTTP_CODE}" -lt 200 ] || [ "${HTTP_CODE}" -ge 300 ]; then
-  echo "publish_platform_provider: API returned HTTP ${HTTP_CODE}" >&2
-  cat "${RESPONSE_BODY}" >&2
-  echo >&2
-  exit 1
-fi
-
-echo "Published platform/${PROVIDER_NAME} v${VERSION} (HTTP ${HTTP_CODE})"
-cat "${RESPONSE_BODY}"
-echo
+echo "Registered ${DIST_NAME} v${VERSION} with Pragma catalog."

--- a/scripts/publish_platform_provider.sh
+++ b/scripts/publish_platform_provider.sh
@@ -29,9 +29,13 @@
 #
 # Optional env vars:
 #   MINT_TTL_SECONDS                   Default: 3600 (max 7200).
-#   PRAGMA_CLI_VERSION                 Default: >=3.0.0. Version specifier
-#                                      passed to `uv run --with
-#                                      pragmatiks-cli<spec>`.
+#   PRAGMA_CLI_VERSION                 Default: >=4.0.0,<5.0.0. Version
+#                                      specifier passed to `uv run
+#                                      --with pragmatiks-cli<spec>`. The
+#                                      `providers register` subcommand
+#                                      first shipped in pragmatiks-cli
+#                                      4.0.0; pin must include it and
+#                                      should not float across majors.
 #   PYPI_POLL_ATTEMPTS                 Default: 30. Times to poll PyPI for
 #                                      wheel availability.
 #   PYPI_POLL_INTERVAL                 Default: 10. Seconds between polls.
@@ -54,7 +58,7 @@ VERSION="${2:?version argument is required}"
 
 PYPROJECT_PATH="${PROVIDER_DIR}/pyproject.toml"
 
-PRAGMA_CLI_VERSION="${PRAGMA_CLI_VERSION:->=3.0.0}"
+PRAGMA_CLI_VERSION="${PRAGMA_CLI_VERSION:->=4.0.0,<5.0.0}"
 MINT_TTL_SECONDS="${MINT_TTL_SECONDS:-3600}"
 PYPI_POLL_ATTEMPTS="${PYPI_POLL_ATTEMPTS:-30}"
 PYPI_POLL_INTERVAL="${PYPI_POLL_INTERVAL:-10}"

--- a/scripts/publish_platform_provider.sh
+++ b/scripts/publish_platform_provider.sh
@@ -64,11 +64,17 @@ if [ ! -f "${PYPROJECT_PATH}" ]; then
   exit 1
 fi
 
+MINT_STDERR="$(mktemp)"
+cleanup() {
+  rm -f "${MINT_STDERR}"
+}
+trap cleanup EXIT
+
 echo "Reading distribution name from ${PYPROJECT_PATH}..."
 
 if ! DIST_NAME=$(
   PYPROJECT_PATH="${PYPROJECT_PATH}" \
-  uv run --isolated python -c '
+  uv run --no-project python -c '
 import os
 import sys
 import tomllib
@@ -92,73 +98,64 @@ fi
 echo "Resolving wheel URL for ${DIST_NAME} v${VERSION} on PyPI..."
 
 PYPI_JSON_URL="https://pypi.org/pypi/${DIST_NAME}/${VERSION}/json"
-PYPI_RESPONSE="$(mktemp)"
-trap 'rm -f "${PYPI_RESPONSE}"' EXIT
 
-WHEEL_FOUND=0
-for attempt in $(seq 1 "${PYPI_POLL_ATTEMPTS}"); do
-  if curl -sfL -o "${PYPI_RESPONSE}" "${PYPI_JSON_URL}"; then
-    HAS_WHEEL=$(
-      PYPI_RESPONSE="${PYPI_RESPONSE}" uv run --isolated python -c '
+# Resolves the wheel URL + sha256 from the PyPI JSON streamed on stdin.
+# Exit codes:
+#   0  exactly one bdist_wheel entry; emits "<url>\n<sha256>" on stdout.
+#   1  zero bdist_wheel entries (wheel not yet propagated — retry).
+#   2  malformed JSON or multiple/ambiguous wheels (fatal — do not retry).
+read -r -d '' WHEEL_RESOLVER_PY <<'PY' || true
 import json
-import os
 import sys
 
-with open(os.environ["PYPI_RESPONSE"], "rb") as f:
-    data = json.load(f)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError as exc:
+    sys.stderr.write(f"invalid PyPI JSON: {exc}\n")
+    sys.exit(2)
 
-for entry in data.get("urls") or []:
-    if entry.get("packagetype") == "bdist_wheel":
-        sys.stdout.write("yes")
-        sys.exit(0)
+wheels = [e for e in (data.get("urls") or []) if e.get("packagetype") == "bdist_wheel"]
+if not wheels:
+    sys.exit(1)
+if len(wheels) > 1:
+    sys.stderr.write(f"expected exactly one bdist_wheel entry, found {len(wheels)}\n")
+    sys.exit(2)
 
-sys.stdout.write("no")
-'
-    )
-    if [ "${HAS_WHEEL}" = "yes" ]; then
-      WHEEL_FOUND=1
-      break
-    fi
+entry = wheels[0]
+url = entry.get("url")
+sha256 = (entry.get("digests") or {}).get("sha256")
+if not url or not sha256:
+    sys.stderr.write("wheel entry is missing url or digests.sha256\n")
+    sys.exit(2)
+
+sys.stdout.write(f"{url}\n{sha256}\n")
+PY
+
+resolve_wheel() {
+  curl -sfL "${PYPI_JSON_URL}" \
+    | uv run --no-project python -c "${WHEEL_RESOLVER_PY}"
+}
+
+WHEEL_META=""
+for ((attempt = 1; attempt <= PYPI_POLL_ATTEMPTS; attempt++)); do
+  if WHEEL_META=$(resolve_wheel); then
+    break
+  fi
+  rc=$?
+  if [ "${rc}" -eq 2 ]; then
+    echo "publish_platform_provider: fatal error resolving wheel on PyPI" >&2
+    exit 1
   fi
   echo "Attempt ${attempt}: wheel not yet visible on PyPI, waiting ${PYPI_POLL_INTERVAL}s..."
   sleep "${PYPI_POLL_INTERVAL}"
 done
 
-if [ "${WHEEL_FOUND}" -ne 1 ]; then
+if [ -z "${WHEEL_META}" ]; then
   echo "publish_platform_provider: timed out waiting for ${DIST_NAME} v${VERSION} wheel on PyPI" >&2
   exit 1
 fi
 
-if ! WHEEL_META=$(
-  PYPI_RESPONSE="${PYPI_RESPONSE}" uv run --isolated python -c '
-import json
-import os
-import sys
-
-with open(os.environ["PYPI_RESPONSE"], "rb") as f:
-    data = json.load(f)
-
-for entry in data.get("urls") or []:
-    if entry.get("packagetype") != "bdist_wheel":
-        continue
-    url = entry.get("url")
-    sha256 = (entry.get("digests") or {}).get("sha256")
-    if not url or not sha256:
-        sys.stderr.write("wheel entry is missing url or digests.sha256\n")
-        sys.exit(1)
-    sys.stdout.write(f"{url}\n{sha256}\n")
-    sys.exit(0)
-
-sys.stderr.write("no bdist_wheel entry found in PyPI response\n")
-sys.exit(1)
-'
-); then
-  echo "publish_platform_provider: failed to extract wheel metadata from PyPI response" >&2
-  exit 1
-fi
-
-WHEEL_URL=$(printf '%s\n' "${WHEEL_META}" | sed -n '1p')
-WHEEL_SHA256=$(printf '%s\n' "${WHEEL_META}" | sed -n '2p')
+{ read -r WHEEL_URL; read -r WHEEL_SHA256; } <<<"${WHEEL_META}"
 
 if [ -z "${WHEEL_URL}" ] || [ -z "${WHEEL_SHA256}" ]; then
   echo "publish_platform_provider: empty wheel URL or sha256" >&2
@@ -169,9 +166,6 @@ echo "Wheel URL: ${WHEEL_URL}"
 echo "Wheel sha256: ${WHEEL_SHA256}"
 
 echo "Minting ConsoleMachine M2M token (ttl=${MINT_TTL_SECONDS}s)..."
-
-MINT_STDERR="$(mktemp)"
-trap 'rm -f "${PYPI_RESPONSE}" "${MINT_STDERR}"' EXIT
 
 if ! TOKEN=$(
   CONSOLE_CLERK_MACHINE_SECRET_KEY="${PRAGMA_CONSOLE_MACHINE_SECRET_KEY}" \

--- a/scripts/publish_platform_provider.sh
+++ b/scripts/publish_platform_provider.sh
@@ -14,8 +14,13 @@
 #     Clerk Machine Secret (ak_...), exports it as PRAGMA_AUTH_TOKEN, and
 #     invokes `pragma providers register` with the wheel URL, sha256,
 #     version, and pyproject path. The CLI reads the rest of the metadata
-#     (display_name, description, icon_url, tags, package, entrypoint) out
-#     of the [tool.pragma] table itself.
+#     (display_name, description, icon_url, tags, package) out of the
+#     [tool.pragma] table itself, then imports the provider package to
+#     extract resource schemas — which is why this script installs the
+#     provider's just-published wheel into the same `uv run` env via
+#     `--with <dist-name>==<version>`. Without that, schema extraction
+#     fails with ModuleNotFoundError for the provider's runtime deps
+#     (e.g. google-cloud-storage, qdrant_client, agno, ...).
 #
 # Required env vars:
 #   PRAGMA_CONSOLE_MACHINE_SECRET_KEY  Clerk Machine Secret (ak_...) for
@@ -214,7 +219,9 @@ if [ -n "${PRAGMA_CONTEXT:-}" ]; then
 fi
 
 PRAGMA_AUTH_TOKEN="${TOKEN}" \
-  uv run --isolated --with "pragmatiks-cli${PRAGMA_CLI_VERSION}" \
+  uv run --isolated \
+    --with "pragmatiks-cli${PRAGMA_CLI_VERSION}" \
+    --with "${DIST_NAME}==${VERSION}" \
     pragma "${CONTEXT_ARGS[@]}" providers register \
     --wheel-url "${WHEEL_URL}" \
     --sha256 "${WHEEL_SHA256}" \


### PR DESCRIPTION
## Summary

- Rewrites `scripts/publish_platform_provider.sh` to call `pragma providers register --wheel-url ... --sha256 ... --version ... --pyproject ...` against a wheel that has just been uploaded to PyPI. The script reads `[project].name` from the provider's pyproject, polls `pypi.org/pypi/<dist-name>/<version>/json` until the `bdist_wheel` entry appears, extracts the wheel URL and `digests.sha256`, mints a short-lived Clerk M2M token from `PRAGMA_CONSOLE_MACHINE_SECRET_KEY`, and invokes the CLI. No more multipart tarball POST against the deleted `/console/providers/<name>/publish` endpoint.
- Switches PyPI auth in `.github/workflows/publish.yaml` to OIDC trusted publishing for all eight per-provider jobs: each job gains `id-token: write`, and `password: ${{ secrets.PYPI_TOKEN }}` is dropped from every `pypa/gh-action-pypi-publish` step so the action falls back to OIDC.
- Pragma API auth keeps the existing Clerk machine-secret flow (`PRAGMA_CONSOLE_MACHINE_SECRET_KEY`) — OIDC trusted publishing covers PyPI only, not the catalog API.

Linear: [PRA-382](https://linear.app/pragmatiks/issue/PRA-382). Supersedes the registration portion of PRA-377.

## Operator follow-ups (must happen on PyPI / GitHub, not in this PR)

1. **Configure trusted publishing on PyPI for each project.** For every `pragmatiks-{gcp,kubernetes,qdrant,agno,supabase,vercel,github,pragma}-provider` project, open the project's *Publishing* tab and add a trusted publisher entry:
   - Owner: `pragmatiks`
   - Repository: `pragma-providers`
   - Workflow: `publish.yaml`
   - Environment: `pypi` (every publish job already declares `environment: pypi`).
2. **After the first OIDC-backed release lands for every provider**, delete the `PYPI_TOKEN` repository secret. The workflow no longer reads it; leaving it in place is just stale credential material.
3. **Once the `pragmatiks` PyPI org is fully set up**, transfer ownership of `pragmatiks-{gcp,kubernetes,qdrant,agno,supabase,vercel,github,pragma}-provider`, `pragmatiks`, and `pragmatiks-sdk` into the org.

## Test plan

- [ ] On a non-prod tag of one provider, dispatch `publish.yaml` and confirm: PyPI upload succeeds via OIDC (no `PYPI_TOKEN`), the script resolves the wheel URL from `pypi.org/.../json`, mints a Clerk token, and `pragma providers register` returns 200.
- [ ] Verify `pragma providers register` produced a catalog row whose wheel URL points at PyPI and whose sha256 matches the JSON digest.
- [ ] Spin up the runtime against the registered version and confirm the wheel installs.
- [ ] After a clean release per provider, confirm `secrets.PYPI_TOKEN` has been deleted from the repo.

## Operator-side context for reviewers

- Trusted publishing is per-project on PyPI. If even one provider's PyPI project is missing the trusted-publisher row at the moment its job runs, that job will fail at the upload step. Stage the PyPI configs **before** merging this PR, or land the PR knowing the next release for any unconfigured provider will fail until its row is added.
- The script still requires `PRAGMA_CONSOLE_MACHINE_SECRET_KEY` and the `clerk-backend-api` mint flow — that is intentional; it's the API auth, not the PyPI auth.