### PR TITLE
feat(gcp): declare explicit runtime entrypoint in [tool.pragma]

### DIFF
--- a/packages/gcp/pyproject.toml
+++ b/packages/gcp/pyproject.toml
@@ -34,6 +34,7 @@ display_name = "Google Cloud Platform"
 description = "Manage GCP resources including Cloud SQL databases, GKE clusters, and secrets through declarative configuration."
 icon_url = "https://cdn.simpleicons.org/googlecloud"
 tags = ["cloud", "gcp", "infrastructure", "database", "kubernetes"]
+entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

Adds an explicit `entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]` to `[tool.pragma]` in `packages/gcp/pyproject.toml`.

The runtime resolver in `pragma-os` already defaults to this exact entrypoint when the field is absent, so this is **metadata-only — no behavioral change**. Stating it explicitly makes the wheel self-describing so future runtimes can override per-provider without code changes.

## Context

PRA-377 originally scoped this entrypoint hardening but the issue was canceled and the change was not picked up by PRA-382 (which only migrated the publish/register flow). This PR closes that gap for the gcp provider.

One of four small per-provider PRs (gcp, kubernetes, qdrant, agno). Per repo policy each provider must be modified independently — no bundling.

## Test plan

- [x] File parses as valid TOML.
- [ ] First release after merge resolves the explicit entrypoint cleanly.