### PR TITLE
feat(qdrant): declare explicit runtime entrypoint in [tool.pragma]

### DIFF
--- a/packages/qdrant/pyproject.toml
+++ b/packages/qdrant/pyproject.toml
@@ -31,6 +31,7 @@ display_name = "Qdrant Vector Database"
 description = "Provision and manage Qdrant vector database instances and collections for similarity search and AI applications."
 icon_url = "https://cdn.simpleicons.org/qdrant"
 tags = ["vector-database", "search", "ai", "embeddings"]
+entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

Adds an explicit `entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]` to `[tool.pragma]` in `packages/qdrant/pyproject.toml`.

The runtime resolver in `pragma-os` already defaults to this exact entrypoint when the field is absent, so this is **metadata-only — no behavioral change**. Stating it explicitly makes the wheel self-describing so future runtimes can override per-provider without code changes.

## Context

PRA-377 originally scoped this entrypoint hardening but the issue was canceled and the change was not picked up by PRA-382 (which only migrated the publish/register flow). This PR closes that gap for the qdrant provider.

One of four small per-provider PRs (gcp, kubernetes, qdrant, agno). Per repo policy each provider must be modified independently — no bundling.

## Test plan

- [x] File parses as valid TOML.
- [ ] First release after merge resolves the explicit entrypoint cleanly.