### PR TITLE
feat(agno): declare explicit runtime entrypoint in [tool.pragma]

### DIFF
--- a/packages/agno/pyproject.toml
+++ b/packages/agno/pyproject.toml
@@ -36,6 +36,7 @@ display_name = "Agno AI Agents"
 description = "Build and deploy AI agents, teams, and knowledge bases with models from OpenAI and Anthropic, MCP tools, and vector storage."
 icon_url = "https://cdn.prod.website-files.com/6796d350b8c706e4533e7e32/68a85d04c4b355c4accb0f9f_256.png"
 tags = ["ai", "agents", "llm", "openai", "anthropic", "knowledge-base"]
+entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

Adds an explicit `entrypoint = ["python", "-m", "pragma_runtime.entrypoint"]` to `[tool.pragma]` in `packages/agno/pyproject.toml`.

The runtime resolver in `pragma-os` already defaults to this exact entrypoint when the field is absent, so this is **metadata-only — no behavioral change**. Stating it explicitly makes the wheel self-describing so future runtimes can override per-provider without code changes.

## Context

PRA-377 originally scoped this entrypoint hardening but the issue was canceled and the change was not picked up by PRA-382 (which only migrated the publish/register flow). This PR closes that gap for the agno provider.

The agno-runner Docker image (`runner/Dockerfile`) has its own `ENTRYPOINT` for the HTTP-API runner path; it is unaffected by this `[tool.pragma].entrypoint`, which only governs the wheel-installed runtime path used when the platform spawns provider workers.

One of four small per-provider PRs (gcp, kubernetes, qdrant, agno). Per repo policy each provider must be modified independently — no bundling.

## Test plan

- [x] File parses as valid TOML.
- [x] Confirmed no conflict with `runner/Dockerfile` ENTRYPOINT (different code path).
- [ ] First release after merge resolves the explicit entrypoint cleanly.