### PR TITLE
fix(publish-script): pin provider wheel via PEP 508 direct reference

### DIFF
--- a/scripts/publish_platform_provider.sh
+++ b/scripts/publish_platform_provider.sh
@@ -18,7 +18,12 @@
 #     [tool.pragma] table itself, then imports the provider package to
 #     extract resource schemas — which is why this script installs the
 #     provider's just-published wheel into the same `uv run` env via
-#     `--with <dist-name>==<version>`. Without that, schema extraction
+#     `--with "<dist-name> @ <wheel-url>"`. The wheel URL is used as a
+#     PEP 508 direct reference (rather than `==<version>` against the
+#     simple index) because the JSON `/pypi/<name>/<ver>/json` endpoint
+#     propagates ahead of the `/simple/<name>/` index uv would otherwise
+#     consult — pinning to the URL we already resolved bypasses that
+#     race entirely. Without provider deps installed, schema extraction
 #     fails with ModuleNotFoundError for the provider's runtime deps
 #     (e.g. google-cloud-storage, qdrant_client, agno, ...).
 #
@@ -225,7 +230,7 @@ fi
 PRAGMA_AUTH_TOKEN="${TOKEN}" \
   uv run --isolated \
     --with "pragmatiks-cli${PRAGMA_CLI_VERSION}" \
-    --with "${DIST_NAME}==${VERSION}" \
+    --with "${DIST_NAME} @ ${WHEEL_URL}" \
     pragma "${CONTEXT_ARGS[@]}" providers register \
     --wheel-url "${WHEEL_URL}" \
     --sha256 "${WHEEL_SHA256}" \


### PR DESCRIPTION
## Summary

Fixes a PyPI propagation race in `scripts/publish_platform_provider.sh`. Every register step that ran within seconds of the wheel upload was failing with:

```
× No solution found when resolving `--with` dependencies:
╰─▶ Because there is no version of pragmatiks-<name>-provider==<ver> ...
    your requirements are unsatisfiable.
```

## Root cause

The script polls `https://pypi.org/pypi/<name>/<ver>/json` until the `bdist_wheel` entry appears, then invokes:

```bash
uv run --isolated \
  --with "pragmatiks-cli>=4.0.0,<5.0.0" \
  --with "<dist-name>==<version>" \
  pragma providers register ...
```

The `--with "<dist-name>==<version>"` form sends uv to the PyPI **simple** index (`/simple/<name>/`), which propagates *behind* the JSON endpoint. So the JSON endpoint reports the wheel as ready, the simple index doesn't, and uv resolves `unsatisfiable`.

## Fix

Switch the second `--with` to a PEP 508 direct reference using the URL the script already has in hand:

```bash
--with "<dist-name> @ <wheel-url>"
```

uv installs the wheel by URL — no simple-index lookup, no race. Transitive deps still resolve normally through the simple index since they were published earlier and are stable.

Verified locally:
```
uv run --no-project --with "pragmatiks-kubernetes-provider @ https://files.pythonhosted.org/.../pragmatiks_kubernetes_provider-1.0.0-py3-none-any.whl" python -c "import kubernetes_provider"
# Installed 51 packages in 92ms — imported successfully
```

## Affected runs

- PRA-382 publish job (3cbfdc1): failed.
- #83/#84/#85/#86 publish jobs (gcp/kubernetes/qdrant/agno): all failed at register step.

In every case the wheel did upload to PyPI successfully — the failure is post-upload, register-side. Re-running the failed publish jobs after this lands should succeed without manual intervention.

## Test plan

- [x] Verified `--with "<name> @ <url>"` syntax with uv against a real published wheel.
- [x] Shellcheck clean.
- [ ] After merge, re-run a failed publish job (e.g. agno @ 3d46653) and confirm register succeeds.