### PR TITLE
fix(publish): mint JWT M2M tokens instead of opaque

### DIFF
--- a/scripts/publish_platform_provider.sh
+++ b/scripts/publish_platform_provider.sh
@@ -189,13 +189,14 @@ if ! TOKEN=$(
 import os
 import sys
 
-from clerk_backend_api import Clerk
+from clerk_backend_api import Clerk, models
 
 ttl = int(os.environ["MINT_TTL_SECONDS"])
 secret = os.environ["CONSOLE_CLERK_MACHINE_SECRET_KEY"]
 
 with Clerk(bearer_auth=secret) as clerk:
     created = clerk.m2m.create_token(
+        token_format=models.TokenFormat.JWT,
         seconds_until_expiration=float(ttl),
         claims=None,
     )


### PR DESCRIPTION
## Summary
- `clerk-backend-api`'s `m2m.create_token` defaults to `TokenFormat.OPAQUE`, which produces a 35-char identifier that requires a Clerk roundtrip to verify.
- The Pragmatiks API verifies bearer tokens locally via JWKS and rejects opaque tokens with HTTP 401 — surfacing as `Error: Not authenticated. Run 'pragma auth login' first.` in CI.
- Switch the mint to `TokenFormat.JWT` so the API can verify the signature directly.

## Repro
- workflow_dispatch run [25558850019](https://github.com/pragmatiks/pragma-providers/actions/runs/25558850019): 5 of 5 attempted publishes (gcp, vercel, github, supabase, qdrant, pragma) failed at the register step with `Not authenticated`.
- Token mint logs `Minted token (length=35)` — opaque tokens are 35 chars; JWTs are several hundred.

## Test plan
- [ ] Re-trigger publish via `workflow_dispatch` with `allow_no_commit=true` after merge to validate registration succeeds end-to-end.