### PR TITLE
chore(publish): pause auto-publish on push (PRA-392)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,9 @@
 name: Publish Providers
 
 on:
-  push:
-    branches:
-      - main
+  # Auto-publish on push to main is paused while platform M2M auth is broken
+  # (api.pragmatiks.io rejects Clerk JWT M2M tokens at /me with HTTP 401).
+  # Tracked in PRA-392. Re-enable the push trigger once register succeeds.
   workflow_dispatch:
     inputs:
       allow_no_commit:


### PR DESCRIPTION
## Summary
- Disable `on: push` trigger in `publish.yaml`. Only `workflow_dispatch` remains.
- Tracked in [PRA-392](https://linear.app/pragmatiks/issue/PRA-392): API rejects Clerk JWT M2M tokens at `/me` (HTTP 401), so registration is broken end-to-end.
- Without this pause, every commit to `main` triggers a cz bump + PyPI upload + register failure cycle, drifting versions away from the catalog.

## Test plan
- [ ] After merge, push a no-op commit and confirm no `Publish Providers` run starts.
- [ ] `gh workflow run publish.yaml -f allow_no_commit=true` still works for manual recovery.
- [ ] Revert this change once PRA-392 lands.