### PR TITLE
fix(publish): hoist provider lookup out of f-string

### DIFF
--- a/scripts/publish_platform_provider.sh
+++ b/scripts/publish_platform_provider.sh
@@ -208,8 +208,9 @@ icon_url = pragma.get("icon_url")
 if icon_url:
     metadata["icon_url"] = icon_url
 
+provider_short = pragma["provider"]
 payload = {
-    "name": f"platform/{pragma['provider']}",
+    "name": f"platform/{provider_short}",
     "version": os.environ["VERSION"],
     "wheel_url": os.environ["WHEEL_URL"],
     "sha256": os.environ["WHEEL_SHA256"],


### PR DESCRIPTION
## Summary
PR #90 left a quoting bug in the inline Python heredoc:
```python
"name": f"platform/{pragma['provider']}",
```
The surrounding `python -c '...'` is single-quoted in bash. The apostrophes inside `pragma['provider']` close and reopen the bash string, so the runner sees `pragma[provider]` (no quotes) and Python raises `NameError: name 'provider' is not defined`.

Pull the lookup into a separate statement so the f-string only references a clean local name:
```python
provider_short = pragma["provider"]
... f"platform/{provider_short}" ...
```
Double quotes pass through bash single-quote heredocs verbatim. The other `pragma["..."]` lookups in the same block already use double quotes — this was the only single-quote slip.

## Repro
- workflow_dispatch run [25578145119](https://github.com/pragmatiks/pragma-providers/actions/runs/25578145119) — every publish failed at `Building Console registration payload` with `NameError: name 'provider' is not defined`.

## Test plan
- [ ] Merge.
- [ ] Re-trigger `workflow_dispatch` with `allow_no_commit=true`.
- [ ] If green, open follow-up to revert PR #89 (re-enable `on: push`).