### PR TITLE
fix(publish): pin --allow-no-commit dispatches to PATCH increment

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -120,7 +120,11 @@ jobs:
       - name: Bump and build
         id: bump
         env:
-          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
+          # `cz bump` defaults to MAJOR when `--allow-no-commit` is set with no
+          # eligible commits. Pin to PATCH so catalog-recovery dispatches can't
+          # bump majors for free. Real `feat:`/`fix:`/`BREAKING CHANGE` commits
+          # on `push` events still drive the increment via the empty default.
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit --increment PATCH' || '' }}
         run: |
           cd packages/gcp
           if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
@@ -219,7 +223,11 @@ jobs:
       - name: Bump and build
         id: bump
         env:
-          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
+          # `cz bump` defaults to MAJOR when `--allow-no-commit` is set with no
+          # eligible commits. Pin to PATCH so catalog-recovery dispatches can't
+          # bump majors for free. Real `feat:`/`fix:`/`BREAKING CHANGE` commits
+          # on `push` events still drive the increment via the empty default.
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit --increment PATCH' || '' }}
         run: |
           cd packages/supabase
           if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
@@ -318,7 +326,11 @@ jobs:
       - name: Bump and build
         id: bump
         env:
-          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
+          # `cz bump` defaults to MAJOR when `--allow-no-commit` is set with no
+          # eligible commits. Pin to PATCH so catalog-recovery dispatches can't
+          # bump majors for free. Real `feat:`/`fix:`/`BREAKING CHANGE` commits
+          # on `push` events still drive the increment via the empty default.
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit --increment PATCH' || '' }}
         run: |
           cd packages/vercel
           if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
@@ -417,7 +429,11 @@ jobs:
       - name: Bump and build
         id: bump
         env:
-          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
+          # `cz bump` defaults to MAJOR when `--allow-no-commit` is set with no
+          # eligible commits. Pin to PATCH so catalog-recovery dispatches can't
+          # bump majors for free. Real `feat:`/`fix:`/`BREAKING CHANGE` commits
+          # on `push` events still drive the increment via the empty default.
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit --increment PATCH' || '' }}
         run: |
           cd packages/github
           if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
@@ -516,7 +532,11 @@ jobs:
       - name: Bump and build
         id: bump
         env:
-          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
+          # `cz bump` defaults to MAJOR when `--allow-no-commit` is set with no
+          # eligible commits. Pin to PATCH so catalog-recovery dispatches can't
+          # bump majors for free. Real `feat:`/`fix:`/`BREAKING CHANGE` commits
+          # on `push` events still drive the increment via the empty default.
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit --increment PATCH' || '' }}
         run: |
           cd packages/pragma
           if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
@@ -647,7 +667,11 @@ jobs:
       - name: Bump and build
         id: bump
         env:
-          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
+          # `cz bump` defaults to MAJOR when `--allow-no-commit` is set with no
+          # eligible commits. Pin to PATCH so catalog-recovery dispatches can't
+          # bump majors for free. Real `feat:`/`fix:`/`BREAKING CHANGE` commits
+          # on `push` events still drive the increment via the empty default.
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit --increment PATCH' || '' }}
         run: |
           cd packages/kubernetes
           if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
@@ -777,7 +801,11 @@ jobs:
       - name: Bump and build
         id: bump
         env:
-          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
+          # `cz bump` defaults to MAJOR when `--allow-no-commit` is set with no
+          # eligible commits. Pin to PATCH so catalog-recovery dispatches can't
+          # bump majors for free. Real `feat:`/`fix:`/`BREAKING CHANGE` commits
+          # on `push` events still drive the increment via the empty default.
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit --increment PATCH' || '' }}
         run: |
           cd packages/qdrant
           if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then
@@ -918,7 +946,11 @@ jobs:
       - name: Bump and build
         id: bump
         env:
-          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
+          # `cz bump` defaults to MAJOR when `--allow-no-commit` is set with no
+          # eligible commits. Pin to PATCH so catalog-recovery dispatches can't
+          # bump majors for free. Real `feat:`/`fix:`/`BREAKING CHANGE` commits
+          # on `push` events still drive the increment via the empty default.
+          ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit --increment PATCH' || '' }}
         run: |
           cd packages/agno
           if cz bump --yes --changelog $ALLOW_NO_COMMIT 2>&1 | tee bump_output.txt; then


### PR DESCRIPTION
## Summary
`cz bump --allow-no-commit` with no eligible commits defaults to **MAJOR**. That's how the PRA-392 recovery loop bumped every affected provider through 4–5 major versions while the Console endpoint was 401/404'ing.

This PR pins all `--allow-no-commit` dispatches to `--increment PATCH`. Real `push`-driven runs keep the empty default and let commitizen pick the increment from conventional commits as before.

```diff
- ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit' || '' }}
+ ALLOW_NO_COMMIT: ${{ inputs.allow_no_commit && '--allow-no-commit --increment PATCH' || '' }}
```

Applied uniformly to all 8 publish-* jobs.

## What this does NOT do
- Does not yank/reset the existing 22 orphan PyPI majors (per direction: keep them).
- Does not re-enable `on: push` (still paused via PR #89 until the Console endpoint is live and PR #91 has been validated end-to-end).

## Test plan
- [ ] After Console endpoint deploys, run `gh workflow run publish.yaml -f allow_no_commit=true` once.
- [ ] Confirm bumps look like `5.0.0 → 5.0.1` (or wherever each provider sits), not `5.0.0 → 6.0.0`.
- [ ] Then revert PR #89 to re-enable `on: push`.