### PR TITLE
fix(publish): mint opaque M2M tokens (revert JWT format)

### DIFF
--- a/scripts/publish_platform_provider.sh
+++ b/scripts/publish_platform_provider.sh
@@ -242,14 +242,13 @@ if ! TOKEN=$(
 import os
 import sys
 
-from clerk_backend_api import Clerk, models
+from clerk_backend_api import Clerk
 
 ttl = int(os.environ["MINT_TTL_SECONDS"])
 secret = os.environ["CONSOLE_CLERK_MACHINE_SECRET_KEY"]
 
 with Clerk(bearer_auth=secret) as clerk:
     created = clerk.m2m.create_token(
-        token_format=models.TokenFormat.JWT,
         seconds_until_expiration=float(ttl),
         claims=None,
     )


### PR DESCRIPTION
## Summary
PR #88 was based on a misdiagnosis. The 35-char OPAQUE token was failing on the **customer-realm** `pragma providers register` flow, but the real bug there was the wrong endpoint, not the token format.

The current script POSTs directly to `/console/provider-versions`. Its auth dependency is:
```python
Clerk(bearer_auth=CONSOLE_CLERK_SECRET_KEY).authenticate_request_async(
    request,
    AuthenticateRequestOptions(accepts_token=["session_token", "m2m_token"]),
)
```
That code path expects opaque `mt_*` M2M tokens (the Clerk default) and verifies them via the `/m2m_tokens/verify` round-trip. JWT-formatted tokens hit `is_signed_in == False` and surface as HTTP 401 `{"detail":"Not authenticated"}`.

Drop `token_format=models.TokenFormat.JWT` so the mint returns the default opaque token.

## Repro
- workflow_dispatch run [25597362356](https://github.com/pragmatiks/pragma-providers/actions/runs/25597362356) — all six attempted publishes returned HTTP 401 from `/console/provider-versions` after PR #88's JWT mint landed.

## Test plan
- [ ] Merge.
- [ ] `gh workflow run publish.yaml -f allow_no_commit=true` — mint should be ~35 chars, register should land 201.
- [ ] If green, revert PR #89 to re-enable `on: push`.