### PR TITLE
chore(publish): re-enable on: push trigger (PRA-392 done)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,9 @@
 name: Publish Providers
 
 on:
-  # Auto-publish on push to main is paused while platform M2M auth is broken
-  # (api.pragmatiks.io rejects Clerk JWT M2M tokens at /me with HTTP 401).
-  # Tracked in PRA-392. Re-enable the push trigger once register succeeds.
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       allow_no_commit:


### PR DESCRIPTION
## Summary
PRA-392 is closed and the catalog has been fully re-registered. Restore the `on: push` trigger so commits to main resume normal cz-bump → PyPI publish → catalog register cycle. Reverts the pause from PR #89.

## Verification
Run [25598652143](https://github.com/pragmatiks/pragma-providers/actions/runs/25598652143) (`register_only=true`) — 8/8 publishes returned HTTP 201:

| Provider | Catalog version |
|---|---|
| pragma | 5.0.2 |
| gcp | 5.0.2 |
| vercel | 4.0.2 |
| github | 4.0.2 |
| supabase | 4.0.2 |
| kubernetes | 1.0.0 |
| qdrant | 6.0.2 |
| agno | 1.0.0 |

## Test plan
- [ ] Merge.
- [ ] Push a no-op `chore:` commit on a small package and confirm only the touched provider's publish job runs (cz emits "No commits found", step skips cleanly).
- [ ] First real `feat:`/`fix:` commit to a provider should bump → PyPI → catalog register, all green.