### PR TITLE
fix(publish): push tags reliably so cz finds previous version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -154,7 +154,7 @@ jobs:
         if: inputs.register_only != true
         run: |
           for i in 1 2 3 4 5; do
-            git pull --rebase origin main && git push origin main --follow-tags && exit 0
+            git pull --rebase origin main && git push origin main --tags && exit 0
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done
@@ -262,7 +262,7 @@ jobs:
         if: inputs.register_only != true
         run: |
           for i in 1 2 3 4 5; do
-            git pull --rebase origin main && git push origin main --follow-tags && exit 0
+            git pull --rebase origin main && git push origin main --tags && exit 0
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done
@@ -370,7 +370,7 @@ jobs:
         if: inputs.register_only != true
         run: |
           for i in 1 2 3 4 5; do
-            git pull --rebase origin main && git push origin main --follow-tags && exit 0
+            git pull --rebase origin main && git push origin main --tags && exit 0
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done
@@ -478,7 +478,7 @@ jobs:
         if: inputs.register_only != true
         run: |
           for i in 1 2 3 4 5; do
-            git pull --rebase origin main && git push origin main --follow-tags && exit 0
+            git pull --rebase origin main && git push origin main --tags && exit 0
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done
@@ -586,7 +586,7 @@ jobs:
         if: inputs.register_only != true
         run: |
           for i in 1 2 3 4 5; do
-            git pull --rebase origin main && git push origin main --follow-tags && exit 0
+            git pull --rebase origin main && git push origin main --tags && exit 0
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done
@@ -726,7 +726,7 @@ jobs:
         if: inputs.register_only != true
         run: |
           for i in 1 2 3 4 5; do
-            git pull --rebase origin main && git push origin main --follow-tags && exit 0
+            git pull --rebase origin main && git push origin main --tags && exit 0
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done
@@ -865,7 +865,7 @@ jobs:
         if: inputs.register_only != true
         run: |
           for i in 1 2 3 4 5; do
-            git pull --rebase origin main && git push origin main --follow-tags && exit 0
+            git pull --rebase origin main && git push origin main --tags && exit 0
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done
@@ -1015,7 +1015,7 @@ jobs:
         if: inputs.register_only != true
         run: |
           for i in 1 2 3 4 5; do
-            git pull --rebase origin main && git push origin main --follow-tags && exit 0
+            git pull --rebase origin main && git push origin main --tags && exit 0
             echo "Push attempt $i failed, retrying in ${i}s..."
             sleep $i
           done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,14 +81,6 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 addopts = ["-v"]
 
-[tool.commitizen]
-name = "cz_conventional_commits"
-version = "0.4.1"
-version_files = ["pyproject.toml:^version"]
-tag_format = "v$version"
-update_changelog_on_bump = true
-changelog_file = "CHANGELOG.md"
-
 [dependency-groups]
 dev = [
     "commitizen>=4.11.0",


### PR DESCRIPTION
## Summary

- **Root cause**: `cz bump` creates **lightweight** tags by default; `git push --follow-tags` only pushes **annotated** tags. So after every successful bump, the `<provider>-v<version>` tag stayed local and never reached origin.
- **Knock-on bug**: on the next push, `cz bump` couldn't find a tag matching the current pyproject version, so it walked the full history, hit an old `feat!:` commit (`3cbfdc1`, PRA-382), classified the increment as MAJOR, and bumped every affected provider one major version for free.
- **Symptom**: run 25598784624 (post-merge auto-trigger of PR #95) bumped gcp 5.0.2 → **6.0.0**, supabase/vercel/github 4.0.2 → **5.0.0**, qdrant 6.0.2 → **7.0.0** with no breaking commits in the relevant range. PyPI versions are now orphaned (can't unpublish).

## Fix

- Replace `--follow-tags` with `--tags` in all 8 publish jobs' `Push version bumps and tags` step. `--tags` pushes every tag regardless of annotation, matching cz's default lightweight tag output.
- Drop the stray `[tool.commitizen]` block from the root `pyproject.toml`. It carried `tag_format = "v$version"` and `version = "0.4.1"`, unrelated to any per-package release. Eliminates the `Multiple config files detected` warning and removes a future footgun if anyone runs `cz bump` from the repo root.

## Out-of-band recovery (already on origin)

Backfilled the missing tags pointing at the bump commits already in main, so the next push doesn't re-walk history and bump another major:

- `gcp-v5.0.2`, `gcp-v6.0.0`
- `supabase-v4.0.2`, `supabase-v5.0.0`
- `vercel-v4.0.2`, `vercel-v5.0.0`
- `github-v4.0.2`, `github-v5.0.0`
- `qdrant-v6.0.2`, `qdrant-v7.0.0`
- `pragma-v5.0.2`

Verified locally with `cz bump --dry-run`: every provider now reports `[NO_COMMITS_TO_BUMP]` or `[NO_COMMITS_FOUND]`.

## Test plan
- [ ] Merge → push event auto-triggers `Publish Providers`
- [ ] Each `Bump and build` step hits `No bump needed for <provider>` (no version output)
- [ ] No `Publish to PyPI` runs (gated on `steps.bump.outputs.version != ''`)
- [ ] No catalog re-registration runs
- [ ] No `Multiple config files detected` warning in logs