### PR TITLE
chore(providers): integrate graphify code-graph MCP (PRA-433)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/graph.json ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}'   || true ;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/graph.json ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}'   || true ;; esac"
+            "command": "command=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$command\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/graph.json ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}'   || true ;; esac"
           }
         ]
       }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+[mcp_servers.graphify]
+command = "uv"
+args = ["run", "--with", "graphifyy", "--with", "mcp", "-m", "graphify.serve", "graphify-out/graph.json"]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/thomas/.local/bin/graphify hook-check"
+            "command": "[ -f graphify-out/graph.json ] && graphify hook-check || true"
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/thomas/.local/bin/graphify hook-check"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ e2e/
 .claude/settings.local.json
 .claude/worktrees/
 .claude/plans/
+
+# graphify
+graphify-out/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,22 @@
+# Build artifacts
+node_modules/
+.venv/
+dist/
+build/
+target/
+.next/
+
+# Python caches
+__pycache__/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+
+# Coverage / test artifacts
+.coverage
+coverage/
+htmlcov/
+
+# Worktrees and graph output (prevent recursion / duplication)
+.claude/worktrees/
+graphify-out/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -17,6 +17,12 @@ __pycache__/
 coverage/
 htmlcov/
 
+# Per-package build artifacts
+packages/*/.venv/
+packages/*/dist/
+packages/*/build/
+packages/*/__pycache__/
+
 # Worktrees and graph output (prevent recursion / duplication)
 .claude/worktrees/
 graphify-out/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "graphify": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with", "graphifyy",
+        "--with", "mcp",
+        "-m", "graphify.serve",
+        "graphify-out/graph.json"
+      ]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,3 +369,15 @@ Every developer dispatch must:
 2. Run `pragmatiks-lint check` locally before opening a PR.
 3. Resolve all 🚨 blockers from the lint pack. ⚠️ findings: address or justify in PR body.
 4. State principle compliance in the callback to the supervisor.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+When the user types `/graphify`, invoke the `skill` tool with `skill: "graphify"` before doing anything else.
+
+Rules:
+- ALWAYS read graphify-out/GRAPH_REPORT.md before reading any source files, running grep/glob searches, or answering codebase questions. The graph is your primary map of the codebase.
+- IF graphify-out/wiki/index.md EXISTS, navigate it instead of reading raw files
+- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,7 +374,7 @@ Every developer dispatch must:
 
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
 
-When the user types `/graphify`, invoke the `skill` tool with `skill: "graphify"` before doing anything else.
+When the user types `$graphify`, invoke the graphify pipeline before doing anything else.
 
 Rules:
 - ALWAYS read graphify-out/GRAPH_REPORT.md before reading any source files, running grep/glob searches, or answering codebase questions. The graph is your primary map of the codebase.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,3 +251,13 @@ Every developer dispatch must:
 2. Run `pragmatiks-lint check` locally before opening a PR.
 3. Resolve all 🚨 blockers from the lint pack. ⚠️ findings: address or justify in PR body.
 4. State principle compliance in the callback to the supervisor.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- ALWAYS read graphify-out/GRAPH_REPORT.md before reading any source files, running grep/glob searches, or answering codebase questions. The graph is your primary map of the codebase.
+- IF graphify-out/wiki/index.md EXISTS, navigate it instead of reading raw files
+- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).


### PR DESCRIPTION
## Summary
- Adds graphify code-graph indexing to this repo.
- New agent sessions in this repo gain `mcp__graphify__*` tools backed by `graphify-out/graph.json` (built locally per clone via `graphify update .`).
- Cross-repo questions bubble up to the supervisor by design — no agent in this repo reaches into another repo's graph.

## Test plan
- [ ] Fresh `git clone` + `task install` + `graphify update .` builds graph cleanly
- [ ] New Claude Code session: `mcp__graphify__graph_stats` returns sane numbers
- [ ] New Codex session: same
- [ ] `## graphify` section appears exactly once in CLAUDE.md and AGENTS.md
- [ ] `graphify-out/` ignored, not tracked

Parent: PRA-429
Linear: PRA-433