### PR TITLE
docs(claude-md): migrate worker protocols from CAO profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,43 @@ class Bucket(Resource[BucketConfig, BucketOutputs]):
 - Test success and failure paths
 - Use `ProviderHarness` from SDK for lifecycle testing
 
+## Evidence-based development
+
+Use MCPs to fact-check before writing code. The cost of a query is far less than a debugging cycle on stale assumptions.
+
+**Use internal knowledge for**: programming skill, language fluency, algorithms, design patterns, general engineering judgment, code comprehension.
+
+**Always query MCPs for**: library API details, framework feature lists, version-specific behavior, current best practice, recent changes — anything where being wrong costs time.
+
+If you find yourself thinking "I'm pretty sure this library does X" or "the API was Y last time I used it" — STOP and query. Training data is months to years out of date; library APIs change. This bites particularly hard in provider code, where cloud-vendor SDKs evolve fast.
+
+### MCP routing
+
+- **context7** (`mcp__context7__resolve-library-id`, `mcp__context7__query-docs`) — authoritative current docs for a specific library / framework / SDK / CLI. Use whenever you need to know how to call a cloud SDK correctly.
+- **deepwiki** (`mcp__deepwiki__ask_question`, `mcp__deepwiki__read_wiki_contents`, `mcp__deepwiki__read_wiki_structure`) — conversational Q&A over an entire OSS GitHub repository. Use for architecture / pattern questions. Pragmatiks repos are indexed at `pragmatiks/{sdk,cli,providers}`.
+- **exa** (`mcp__exa__web_search_exa`, `mcp__exa__get_code_context_exa`, `mcp__exa__crawling_exa`) — live web search (release notes, blog posts, GitHub issues) and direct code extraction from a GitHub URL. Use when context7 / deepwiki cannot answer. Skip `deep_researcher_*` unless multi-source synthesis is explicitly requested.
+- **claude-mem** (`mcp__plugin_claude-mem_mcp-search__smart_search`, `mcp__plugin_claude-mem_mcp-search__search`, `mcp__plugin_claude-mem_mcp-search__get_observations`) — search prior session memory. Use when working in an area that has prior session decisions. Cite observation IDs.
+
+## Solution preference order
+
+Before writing custom code in a provider, work through these in order:
+
+1. **Reuse what is already in the project.** Check the provider's `pyproject.toml` and lockfile for an existing dependency that solves the problem. Grep / graphify the provider's codebase for prior patterns. The cheapest correct answer is already on disk.
+2. **Adopt an established external library.** Look for popular, state-of-the-art, actively maintained libraries — typically the cloud vendor's official SDK. Verify GitHub stars / last release / open critical issues / maintainer reputation. A boring widely-used library beats a custom implementation.
+3. **Custom code, only as a last resort.** Only after 1 and 2 fail should you write it from scratch.
+
+Prefer the simplest solution that meets the requirement. Avoid abstractions for hypothetical future needs.
+
+## New dependency proposal (BLOCKING)
+
+If your work requires adding a new top-level dependency to a provider package, STOP before installing it.
+
+1. **Research candidates.** For each viable candidate, record: name, version, license, maintainer (individual / org / foundation) and their track record, last release date and release frequency, popularity signals (GitHub stars, downloads, ecosystem use), known issues affecting us (security advisories, deprecated APIs), fit and trade-offs, at least one realistic alternative considered.
+2. **Present findings to the user** with a one-sentence recommendation. Do NOT install the dependency or write code that uses it.
+3. **Wait for approval.** Install only after explicit user approval (`uv add` inside the relevant `packages/<provider>/` directory). If rejected, revisit the solution preference order.
+
+This applies to any new top-level dependency. It does NOT apply to transitive dependencies pulled in by existing direct deps. Each provider has its own dependency set — keep this per-package and never share deps across providers via the workspace root.
+
 ## Publishing to PyPI
 
 Each provider is a separate PyPI package:
@@ -240,6 +277,8 @@ Every reviewer dispatch must:
    Severities: 🚨 blocker · ⚠️ important · 💡 nit.
 
 4. Final verdict: `APPROVE` / `APPROVE_WITH_NITS` / `REQUEST_CHANGES`.
+5. **Evidence-check the diff.** If the diff cites library behavior, version-specific features, or external API shapes you cannot fully verify from the code alone, query context7 / deepwiki / exa to confirm. Cloud SDKs change often — verify before approving.
+6. **Dependency scrutiny.** If the diff adds a new top-level dependency, confirm the PR description includes the new-dependency proposal (research, alternatives, maintainer signals). Missing proposal = blocker. Spot-check the proposal's claims via exa or deepwiki. Confirm no existing provider dependency could have solved the problem.
 
 A reviewer who fails to invoke programmatic tooling but only eyeballs the diff is incomplete and should be re-run.
 


### PR DESCRIPTION
## Summary

Migrates framework-agnostic worker protocols from the CAO developer/reviewer agent profiles into `CLAUDE.md`, so the repo's agent guidance is self-contained when read outside the CAO orchestrator.

Three new top-level sections inserted between `## Testing` and `## Publishing to PyPI`:

- **Evidence-based development** — when to use internal knowledge vs query MCPs, plus MCP routing (context7, deepwiki, exa, claude-mem).
- **Solution preference order** — reuse → established library → custom code, in that order.
- **New dependency proposal (BLOCKING)** — research / present / wait-for-approval flow for any new top-level dep added to a provider package.

Reviewer protocol extended with two new bullets (5: evidence-check; 6: dependency scrutiny).

No CAO-specific terminology (`CAO_TERMINAL_ID`, `send_message`, `handoff`, `assign`, `.cao-tasks/`) was introduced — that was an explicit constraint of the migration. Existing sections (Engineering Principles 1–12, graphify, etc.) are unchanged.

Docs-only: `+39 / -0`, single file.

## Test plan

- [ ] Skim diff to confirm only `CLAUDE.md` is modified and only new content was added (no edits to existing sections).
- [ ] Verify the three new sections sit between `## Testing` and `## Publishing to PyPI`.
- [ ] Verify the two new bullets are appended after step 4 of `### Reviewer protocol` and before the "A reviewer who fails..." paragraph.
- [ ] Confirm no CAO terminology was introduced.
